### PR TITLE
Add Makefile in order to build the command line tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+prefix ?= /usr/local
+bindir = $(prefix)/bin
+libdir = $(prefix)/lib
+
+build:
+	swift build -c release --disable-sandbox
+
+install: build
+	install ".build/release/xcparse" "$(bindir)"
+
+uninstall:
+	rm -rf "$(bindir)/xcparse"
+
+clean:
+	rm -rf .build
+
+.PHONY: build install uninstall clean


### PR DESCRIPTION
**Change Description:** These changes allow for running make's build, install, uninstall, & clean commands in order to build the xcparse command line tool.  We're going to use this to try and build from source for xcparse rather than using a pre-built binary with Homebrew.

**Test Plan/Testing Performed:** Tested with these changes locally that the following would result in a good xcparse install & uninstall.

make install
make clean
xcparse -h
make uninstall
xcparse -h
