### PR TITLE
Added ability to extract 'xccovarchive' required to merge code covera…

### DIFF
--- a/Sources/xcparse/XCResultToolCommand.swift
+++ b/Sources/xcparse/XCResultToolCommand.swift
@@ -1,0 +1,42 @@
+//
+//  XCResultToolCommand.swift
+//  xcparse
+//
+//  Created by Nikita Zamalyutdinov on 10/03/19.
+//  Copyright © 2019 ChargePoint, Inc. All rights reserved.
+//
+
+class XCResultToolCommand {
+    
+    let commandPrefix = "xcrun xcresulttool"
+    
+    let console = Console()
+    
+    func run() {
+        preconditionFailure("This method should be overriden")
+    }
+    
+    class Export: XCResultToolCommand {
+        enum ExportType: String {
+            case file = "file"
+            case directory = "directory"
+        }
+        
+        var path: String = ""
+        var id: String = ""
+        var outputPath: String = ""
+        var type: ExportType = ExportType.file
+        
+        init(path: String, id: String, outputPath: String, type: ExportType) {
+            self.path = path
+            self.id = id
+            self.outputPath = outputPath
+            self.type = type
+        }
+        
+        override func run() {
+            let command = "\(commandPrefix) export --path \"\(self.path)\" --id \(self.id) --output-path \"\(self.outputPath)\" --type \(self.type.rawValue)"
+            console.shellCommand(command)
+        }
+    }
+}


### PR DESCRIPTION
…ge data.

XCParse now extracts 'xccovarchive' in addition to 'xccovreport', both artifacts required to merge code coverage [see 'Guide to merge code coverage'](https://medium.com/xcblog/xccov-diff-and-merge-swift-ios-code-coverage-a95b1d06be5b).

I've installed my version of 'xcparse' via Make and checked it works correctly.
![Screenshot 2019-10-03 at 17 42 33](https://user-images.githubusercontent.com/16858432/66137073-36cadc00-e605-11e9-9ca6-275e94ad61ec.png)
