### PR TITLE
Address warnings, clean up loop logic, & XCResultToolCommand consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A command line tool to extract code coverage & screenshots from Xcode 11+ XCResult files.
 
+To learn more about Xcode 11's xcresult format, read [Rishab Sukumar's post on the ChargePoint Engineering blog](https://www.chargepoint.com/engineering/xcparse/)
+
 ## Installation 
 
 Enter the following command  in terminal.

--- a/Sources/xcparse/Console.swift
+++ b/Sources/xcparse/Console.swift
@@ -25,8 +25,6 @@ class Console {
     }
     
     func printUsage() {
-
-        let executableName = (CommandLine.arguments[0] as NSString).lastPathComponent
         writeMessage("usage (static mode): xcparse [-hq] [-s xcresultPath destination] [-x xcresultPath destination]\n")
         writeMessage("xcparse only accepts a single option at a time.\n")
         writeMessage("usage (interactive mode): xcparse\n")
@@ -39,7 +37,7 @@ class Console {
     // MARK: -
     // MARK: Shell
     // user3064009's answer on https://stackoverflow.com/questions/26971240/how-do-i-run-an-terminal-command-in-a-swift-script-e-g-xcodebuild
-    func shellCommand(_ command: String) -> String {
+    @discardableResult func shellCommand(_ command: String) -> String {
         let task = Process()
         task.launchPath = "/bin/bash"
         task.arguments = ["-c", command]

--- a/Sources/xcparse/XCResultToolCommand.swift
+++ b/Sources/xcparse/XCResultToolCommand.swift
@@ -12,8 +12,13 @@ class XCResultToolCommand {
     
     let console = Console()
     
-    func run() {
+    @discardableResult func run() -> String {
         preconditionFailure("This method should be overriden")
+    }
+
+    enum FormatType: String {
+        case raw = "raw"
+        case json = "json"
     }
     
     class Export: XCResultToolCommand {
@@ -34,9 +39,35 @@ class XCResultToolCommand {
             self.type = type
         }
         
-        override func run() {
+        @discardableResult override func run() -> String {
             let command = "\(commandPrefix) export --path \"\(self.path)\" --id \(self.id) --output-path \"\(self.outputPath)\" --type \(self.type.rawValue)"
-            console.shellCommand(command)
+            return console.shellCommand(command)
+        }
+    }
+
+    class Get: XCResultToolCommand {
+        var path: String = ""
+        var id: String = ""
+        var outputPath: String = ""
+        var format = FormatType.raw
+
+        init(path: String, id: String, outputPath: String, format: FormatType) {
+            self.path = path
+            self.id = id
+            self.outputPath = outputPath
+            self.format = format
+        }
+
+        @discardableResult override func run() -> String {
+            var command = "\(commandPrefix) get --path \"\(self.path)\" --format \(self.format)"
+            if self.id != "" {
+                command += " --id \"\(self.id)\""
+            }
+            if self.outputPath != "" {
+                command += " > \"\(self.outputPath)\""
+            }
+
+            return console.shellCommand(command)
         }
     }
 }


### PR DESCRIPTION
**Change Description:** These changes address a few different warnings that existed in the code base about unused results or variables.  Biggest change is the loop logic to move away from some of the hard-coding in knowing how the test runs tend to set up summary objects.  Additionally, consolidated on the XCResultToolCommand and removed hand-rolled xcresulttool calls.

**Test Plan/Testing Performed:** Ran with these changes and saw the screenshots were still output as before.  This doesn't address the illegal instruction issue yet, those changes are in a separate, upcoming PR.
