### PR TITLE
Fixes #16 keyNotFound ActionTestSummaryGroupCodingKeys subtests

### DIFF
--- a/Sources/XCParseCore/ActionTestActivitySummary.swift
+++ b/Sources/XCParseCore/ActionTestActivitySummary.swift
@@ -35,7 +35,7 @@ open class ActionTestActivitySummary : Codable {
         start = try container.decodeXCResultTypeIfPresent(forKey: .start)
         finish = try container.decodeXCResultTypeIfPresent(forKey: .finish)
 
-        attachments = try container.decodeIfPresent(XCResultArrayValue<ActionTestAttachment>.self, forKey: .attachments)?.values ?? []
-        subactivities = try container.decodeIfPresent(XCResultArrayValue<ActionTestActivitySummary>.self, forKey: .subactivities)?.values ?? []
+        attachments = try container.decodeXCResultArray(forKey: .attachments)
+        subactivities = try container.decodeXCResultArray(forKey: .subactivities)
     }
 }

--- a/Sources/XCParseCore/ActionTestPerformanceMetricSummary.swift
+++ b/Sources/XCParseCore/ActionTestPerformanceMetricSummary.swift
@@ -38,8 +38,7 @@ open class ActionTestPerformanceMetricSummary : Codable {
         displayName = try container.decodeXCResultType(forKey: .displayName)
         unitOfMeasurement = try container.decodeXCResultType(forKey: .unitOfMeasurement)
 
-        let measurementValues = try container.decode(XCResultArrayValue<Double>.self, forKey: .measurements)
-        measurements = measurementValues.values
+        measurements = try container.decodeXCResultArray(forKey: .measurements)
 
         identifier = try container.decodeXCResultTypeIfPresent(forKey: .identifier)
         baselineName = try container.decodeXCResultTypeIfPresent(forKey: .baselineName)

--- a/Sources/XCParseCore/ActionTestPlanRunSummaries.swift
+++ b/Sources/XCParseCore/ActionTestPlanRunSummaries.swift
@@ -17,8 +17,6 @@ open class ActionTestPlanRunSummaries : Codable {
 
      required public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: ActionTestPlanRunSummariesCodingKeys.self)
-
-        let summaryValues = try container.decode(XCResultArrayValue<ActionTestPlanRunSummary>.self, forKey: .summaries)
-        summaries = summaryValues.values
+        summaries = try container.decodeXCResultArray(forKey: .summaries)
     }
 }

--- a/Sources/XCParseCore/ActionTestPlanRunSummary.swift
+++ b/Sources/XCParseCore/ActionTestPlanRunSummary.swift
@@ -18,8 +18,7 @@ open class ActionTestPlanRunSummary : ActionAbstractTestSummary {
      required public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: ActionTestPlanRunSummaryCodingKeys.self)
 
-        let summaryValues = try container.decode(XCResultArrayValue<ActionTestableSummary>.self, forKey: .testableSummaries)
-        testableSummaries = summaryValues.values
+        testableSummaries = try container.decodeXCResultArray(forKey: .testableSummaries)
 
         try super.init(from: decoder)
     }

--- a/Sources/XCParseCore/ActionTestSummary.swift
+++ b/Sources/XCParseCore/ActionTestSummary.swift
@@ -28,9 +28,9 @@ open class ActionTestSummary : ActionTestSummaryIdentifiableObject {
         duration = try container.decodeXCResultType(forKey: .duration)
         testStatus = try container.decodeXCResultType(forKey: .testStatus)
 
-        performanceMetrics = try container.decodeIfPresent(XCResultArrayValue<ActionTestPerformanceMetricSummary>.self, forKey: .performanceMetrics)?.values ?? []
-        failureSummaries = try container.decodeIfPresent(XCResultArrayValue<ActionTestFailureSummary>.self, forKey: .failureSummaries)?.values ?? []
-        activitySummaries = try container.decodeIfPresent(XCResultArrayValue<ActionTestActivitySummary>.self, forKey: .activitySummaries)?.values ?? []
+        performanceMetrics = try container.decodeXCResultArray(forKey: .performanceMetrics)
+        failureSummaries = try container.decodeXCResultArray(forKey: .failureSummaries)
+        activitySummaries = try container.decodeXCResultArray(forKey: .activitySummaries)
 
         try super.init(from: decoder)
     }

--- a/Sources/XCParseCore/ActionTestSummaryGroup.swift
+++ b/Sources/XCParseCore/ActionTestSummaryGroup.swift
@@ -20,9 +20,7 @@ open class ActionTestSummaryGroup : ActionTestSummaryIdentifiableObject {
      required public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: ActionTestSummaryGroupCodingKeys.self)
         duration = try container.decodeXCResultType(forKey: .duration)
-
-        let subtestsValues = try container.decode(XCResultArrayValue<ActionTestSummaryIdentifiableObject>.self, forKey: .subtests)
-        subtests = subtestsValues.values
+        subtests = try container.decodeXCResultArray(forKey: .subtests)
         try super.init(from: decoder)
     }
 }

--- a/Sources/XCParseCore/ActionTestableSummary.swift
+++ b/Sources/XCParseCore/ActionTestableSummary.swift
@@ -35,11 +35,11 @@ open class ActionTestableSummary : ActionAbstractTestSummary {
         targetName = try container.decodeXCResultTypeIfPresent(forKey: .targetName)
         testKind = try container.decodeXCResultTypeIfPresent(forKey: .testKind)
 
-        tests = try container.decodeIfPresent(XCResultArrayValue<ActionTestSummaryIdentifiableObject>.self, forKey: .tests)?.values ?? []
+        tests = try container.decodeXCResultArray(forKey: .tests)
 
         diagnosticsDirectoryName = try container.decodeXCResultTypeIfPresent(forKey: .diagnosticsDirectoryName)
 
-        failureSummaries = try container.decodeIfPresent(XCResultArrayValue<ActionTestFailureSummary>.self, forKey: .failureSummaries)?.values ?? []
+        failureSummaries = try container.decodeXCResultArray(forKey: .failureSummaries)
 
         testLanguage = try container.decodeXCResultTypeIfPresent(forKey: .testLanguage)
         testRegion = try container.decodeXCResultTypeIfPresent(forKey: .testRegion)

--- a/Sources/XCParseCore/ActionsInvocationRecord.swift
+++ b/Sources/XCParseCore/ActionsInvocationRecord.swift
@@ -29,8 +29,7 @@ public class ActionsInvocationRecord : Codable {
         metrics = try container.decodeXCResultObject(forKey: .metrics)
         issues = try container.decodeXCResultObject(forKey: .issues)
 
-        let actionValues = try container.decode(XCResultArrayValue<ActionRecord>.self, forKey: .actions)
-        actions = actionValues.values
+        actions = try container.decodeXCResultArray(forKey: .actions)
 
         archive = try container.decodeXCResultObjectIfPresent(forKey: .archive)
     }

--- a/Sources/XCParseCore/ActivityLogMessage.swift
+++ b/Sources/XCParseCore/ActivityLogMessage.swift
@@ -33,7 +33,6 @@ open class ActivityLogMessage : Codable {
         category = try container.decodeXCResultTypeIfPresent(forKey: .category)
         location = try container.decodeXCResultObjectIfPresent(forKey: .location)
 
-        let annotationValues = try container.decode(XCResultArrayValue<ActivityLogMessageAnnotation>.self, forKey: .annotations)
-        annotations = annotationValues.values
+        annotations = try container.decodeXCResultArray(forKey: .annotations)
     }
 }

--- a/Sources/XCParseCore/ActivityLogSection.swift
+++ b/Sources/XCParseCore/ActivityLogSection.swift
@@ -35,10 +35,8 @@ open class ActivityLogSection : Codable {
         duration = try container.decodeXCResultType(forKey: .duration)
         result = try container.decodeXCResultTypeIfPresent(forKey: .result)
 
-        let subsectionValues = try container.decode(XCResultArrayValue<ActivityLogSection>.self, forKey: .subsections)
-        subsections = subsectionValues.values
+        subsections = try container.decodeXCResultArray(forKey: .subsections)
 
-        let messageValues = try container.decode(XCResultArrayValue<ActivityLogMessage>.self, forKey: .messages)
-        messages = messageValues.values
+        messages = try container.decodeXCResultArray(forKey: .messages)
     }
 }

--- a/Sources/XCParseCore/ResultIssueSummaries.swift
+++ b/Sources/XCParseCore/ResultIssueSummaries.swift
@@ -23,9 +23,9 @@ open class ResultIssueSummaries : Codable {
 
      required public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: ResultIssueSummariesCodingKeys.self)
-        analyzerWarningSummaries = try container.decodeIfPresent(XCResultArrayValue<IssueSummary>.self, forKey: .analyzerWarningSummaries)?.values ?? []
-        errorSummaries = try container.decodeIfPresent(XCResultArrayValue<IssueSummary>.self, forKey: .errorSummaries)?.values ?? []
-        testFailureSummaries = try container.decodeIfPresent(XCResultArrayValue<TestFailureIssueSummary>.self, forKey: .testFailureSummaries)?.values ?? []
-        warningSummaries = try container.decodeIfPresent(XCResultArrayValue<IssueSummary>.self, forKey: .warningSummaries)?.values ?? []
+        analyzerWarningSummaries = try container.decodeXCResultArray(forKey: .analyzerWarningSummaries)
+        errorSummaries = try container.decodeXCResultArray(forKey: .errorSummaries)
+        testFailureSummaries = try container.decodeXCResultArray(forKey: .testFailureSummaries)
+        warningSummaries = try container.decodeXCResultArray(forKey: .warningSummaries)
     }
 }

--- a/Sources/XCParseCore/XCPResultDecoding.swift
+++ b/Sources/XCParseCore/XCPResultDecoding.swift
@@ -291,6 +291,15 @@ extension KeyedDecodingContainer {
         let resultValueType = try self.decodeIfPresent(XCResultValueType.self, forKey: key)
         return resultValueType?.getValue() as! T?
     }
+
+    func decodeXCResultArray<T: Codable>(forKey key: KeyedDecodingContainer<K>.Key) throws -> [T] {
+        let arrayValues = try self.decodeIfPresent(XCResultArrayValue<T>.self, forKey: key)
+        if let retval = arrayValues?.values {
+            return retval
+        } else {
+            return []
+        }
+    }
     
     func decodeXCResultObject<T: Codable>(forKey key: K) throws -> T {
         let resultObject = try self.decode(XCResultObject.self, forKey: key)

--- a/Sources/xcparse/XCPParser.swift
+++ b/Sources/xcparse/XCPParser.swift
@@ -28,6 +28,7 @@ enum OptionType: String {
 }
 
 class XCPParser {
+    let xcparseVersion = "0.3.1"
     
     let console = Console()
 
@@ -214,7 +215,7 @@ class XCPParser {
     }
     
     func interactiveMode() throws {
-        console.writeMessage("Welcome to xcparse. This program can extract screenshots and coverage files from an *.xcresult file.")
+        console.writeMessage("Welcome to xcparse \(xcparseVersion). This program can extract screenshots and coverage files from an *.xcresult file.")
         var shouldQuit = false
         while !shouldQuit {
             console.writeMessage("Type 's' to extract screenshots, 'x' to extract code coverage files, 'h' for help, or 'q' to quit.")

--- a/Tests/xcparseTests/xcparseTests.swift
+++ b/Tests/xcparseTests/xcparseTests.swift
@@ -29,6 +29,10 @@ final class xcparseTests: XCTestCase {
         XCTAssertEqual(output, "Hello, world!\n")
     }
 
+    func testActionTestSummaryGroup() throws {
+        
+    }
+
     /// Returns path to the built products directory.
     var productsDirectory: URL {
       #if os(macOS)

--- a/Tests/xcparseTests/xcparseTests.swift
+++ b/Tests/xcparseTests/xcparseTests.swift
@@ -29,10 +29,6 @@ final class xcparseTests: XCTestCase {
         XCTAssertEqual(output, "Hello, world!\n")
     }
 
-    func testActionTestSummaryGroup() throws {
-        
-    }
-
     /// Returns path to the built products directory.
     var productsDirectory: URL {
       #if os(macOS)


### PR DESCRIPTION
**Change Description:** These changes address the strict parsing issue with non-optional arrays #16 .  If the JSON from xcresulttool did not return a key/value for the non-optional arrays, we would end up crashing with Illegal Instruction 4 keyNotFound as we were requiring to find that key.  These changes make it so that for these non-optional arrays, we see if the key is present in the JSON & use it if so.  If it isn't, we fill in with an empty array.

**Test Plan/Testing Performed:** Ran against SwiftiumTestingKit which saw this & saw correct parsing.  Also ran against our internal Xcode 10 & Xcode 11 xcresults.
