### PR TITLE
Address inability to export files with bash sensitive characters in filename

### DIFF
--- a/Sources/XCParseCore/ActionTestAttachment.swift
+++ b/Sources/XCParseCore/ActionTestAttachment.swift
@@ -9,6 +9,12 @@
 import Foundation
 
 open class ActionTestAttachment : Codable {
+    enum UniformTypeIdentifier: String {
+        case jpeg = "public.jpeg"
+        case png = "public.png"
+        case txt = "public.plain-text"
+    }
+
     public let uniformTypeIdentifier: String
     public let name: String?
     public let timestamp: Date?

--- a/Sources/xcparse/XCPParser.swift
+++ b/Sources/xcparse/XCPParser.swift
@@ -139,10 +139,13 @@ class XCPParser {
                 attachments.append(contentsOf: summaryAttachments)
             }
         }
-        
-        console.shellCommand("mkdir \"\(destination)\"/testScreenshots/")
+
+        let destinationURL = URL.init(fileURLWithPath: destination)
+        let screenshotsDirURL = destinationURL.appendingPathComponent("testScreenshots")
+
+        console.shellCommand("mkdir \"\(screenshotsDirURL.path)\"")
         for attachment in attachments {
-            XCResultToolCommand.Export(path: xcresultPath, attachment: attachment, outputPath: "\(destination)/testScreenshots/").run()
+            XCResultToolCommand.Export(path: xcresultPath, attachment: attachment, outputPath: screenshotsDirURL.path).run()
         }
     }
     

--- a/Sources/xcparse/XCResultToolCommand.swift
+++ b/Sources/xcparse/XCResultToolCommand.swift
@@ -52,7 +52,11 @@ class XCResultToolCommand {
                 let filename = attachment.filename ?? identifier
                 let attachmentOutputPath = URL.init(fileURLWithPath: outputPath).appendingPathComponent(filename)
 
-                self.outputPath = attachmentOutputPath.path
+                var proposedOutputPath = attachmentOutputPath.path
+                proposedOutputPath = proposedOutputPath.replacingOccurrences(of: "\"", with: "\\\"")
+                proposedOutputPath = proposedOutputPath.replacingOccurrences(of: "$", with: "\\$")
+                proposedOutputPath = proposedOutputPath.replacingOccurrences(of: "`", with: "\\`")
+                self.outputPath = proposedOutputPath
             }
         }
         


### PR DESCRIPTION
**Change Description:** These changes make it so that we escape various characters that are sensitive in bash when contained with double-quotes.  This should allow exporting files like the debug descriptions without seeing bash bash us about unknown commands.

**Test Plan/Testing Performed:** Tested with these changes that an XCResult with a text file with a name containing backtick and double quotes could be successfully exported.
