### PR TITLE
Address #19 screenshots missing in 0.3.1

### DIFF
--- a/Sources/xcparse/Console.swift
+++ b/Sources/xcparse/Console.swift
@@ -54,9 +54,7 @@ class Console {
     // MARK: Shell
     // user3064009's answer on https://stackoverflow.com/questions/26971240/how-do-i-run-an-terminal-command-in-a-swift-script-e-g-xcodebuild
     @discardableResult func shellCommand(_ command: String) -> String {
-        if self.verbose == true {
-            print("Command: \(command)\n")
-        }
+        self.logVerboseMessage("Command: \(command)\n")
 
         let task = Process()
         task.launchPath = "/bin/bash"

--- a/Sources/xcparse/Console.swift
+++ b/Sources/xcparse/Console.swift
@@ -14,6 +14,21 @@ enum OutputType {
 }
 
 class Console {
+    var verbose = false
+
+    init() {
+        self.verbose = false
+    }
+
+    init(verbose: Bool) {
+        self.verbose = verbose
+    }
+
+    func logVerboseMessage(_ message: String) {
+        if self.verbose == true {
+            self.writeMessage(message)
+        }
+    }
     
     func writeMessage(_ message: String, to: OutputType = .standard) {
       switch to {
@@ -30,6 +45,7 @@ class Console {
         writeMessage("usage (interactive mode): xcparse\n")
         writeMessage(" -s, --screenshots : Extracts screenshots from xcresult file at xcresultPath and saves it in destination folder.")
         writeMessage(" -x, --xcov : Extracts coverage from xcresult file at xcresultPath and saves it in destination folder.")
+        writeMessage(" -v, --verbose : Run in verbose mode.")
         writeMessage(" -h, --help : Prints usage message.")
         writeMessage(" -q, --quit : Exits interactive mode. Cannot be used in static mode.")
     }
@@ -38,6 +54,10 @@ class Console {
     // MARK: Shell
     // user3064009's answer on https://stackoverflow.com/questions/26971240/how-do-i-run-an-terminal-command-in-a-swift-script-e-g-xcodebuild
     @discardableResult func shellCommand(_ command: String) -> String {
+        if self.verbose == true {
+            print("Command: \(command)\n")
+        }
+
         let task = Process()
         task.launchPath = "/bin/bash"
         task.arguments = ["-c", command]

--- a/Sources/xcparse/XCPParser.swift
+++ b/Sources/xcparse/XCPParser.swift
@@ -30,7 +30,7 @@ enum OptionType: String {
 }
 
 class XCPParser {
-    let xcparseVersion = "0.3.1"
+    let xcparseVersion = "0.3.2"
     
     var console = Console()
 

--- a/Sources/xcparse/XCResultToolCommand.swift
+++ b/Sources/xcparse/XCResultToolCommand.swift
@@ -13,7 +13,15 @@ class XCResultToolCommand {
     
     let commandPrefix = "xcrun xcresulttool"
     
-    let console = Console()
+    let console: Console
+
+    init() {
+        self.console = Console()
+    }
+
+    init(withConsole console: Console) {
+        self.console = console
+    }
     
     @discardableResult func run() -> String {
         preconditionFailure("This method should be overriden")
@@ -35,14 +43,16 @@ class XCResultToolCommand {
         var outputPath: String = ""
         var type: ExportType = ExportType.file
         
-        init(path: String, id: String, outputPath: String, type: ExportType) {
+        init(path: String, id: String, outputPath: String, type: ExportType, console: Console = Console()) {
             self.path = path
             self.id = id
             self.outputPath = outputPath
             self.type = type
+
+            super.init(withConsole: console)
         }
 
-        init(path: String, attachment: ActionTestAttachment, outputPath: String) {
+        init(path: String, attachment: ActionTestAttachment, outputPath: String, console: Console = Console()) {
             self.path = path
 
             if let identifier = attachment.payloadRef?.id {
@@ -58,6 +68,8 @@ class XCResultToolCommand {
                 proposedOutputPath = proposedOutputPath.replacingOccurrences(of: "`", with: "\\`")
                 self.outputPath = proposedOutputPath
             }
+
+            super.init(withConsole: console)
         }
         
         @discardableResult override func run() -> String {
@@ -72,11 +84,13 @@ class XCResultToolCommand {
         var outputPath: String = ""
         var format = FormatType.raw
 
-        init(path: String, id: String, outputPath: String, format: FormatType) {
+        init(path: String, id: String, outputPath: String, format: FormatType, console: Console = Console()) {
             self.path = path
             self.id = id
             self.outputPath = outputPath
             self.format = format
+
+            super.init(withConsole: console)
         }
 
         @discardableResult override func run() -> String {
@@ -88,7 +102,10 @@ class XCResultToolCommand {
                 command += " > \"\(self.outputPath)\""
             }
 
-            return console.shellCommand(command)
+            let commandOutput = console.shellCommand(command)
+            self.console.logVerboseMessage(commandOutput)
+
+            return commandOutput
         }
     }
 
@@ -97,10 +114,12 @@ class XCResultToolCommand {
         var path: String = ""
         var version: Int?
 
-        init(id: String, path: String, version: Int?) {
+        init(id: String, path: String, version: Int?, console: Console = Console()) {
             self.id = id
             self.path = path
             self.version = version
+
+            super.init(withConsole: console)
         }
 
         @discardableResult override func run() -> String {
@@ -111,22 +130,29 @@ class XCResultToolCommand {
             if let version = self.version {
                 command += " --version \(version)"
             }
+            let commandOutput = console.shellCommand(command)
+            self.console.logVerboseMessage(commandOutput)
 
-            return console.shellCommand(command)
+            return commandOutput
         }
     }
 
     class MetadataGet: XCResultToolCommand {
         var path: String = ""
 
-        init(path: String) {
+        init(path: String, console: Console = Console()) {
             self.path = path
+
+            super.init(withConsole: console)
         }
 
         @discardableResult override func run() -> String {
             let command = "\(commandPrefix) metadata get --path \"\(self.path)\""
 
-            return console.shellCommand(command)
+            let commandOutput = console.shellCommand(command)
+            self.console.logVerboseMessage(commandOutput)
+
+            return commandOutput
         }
     }
 }


### PR DESCRIPTION
**Change Description:** These changes fix #19 where screenshots were missing from 0.3.1 on some xcresults.  The cause of this was that there was an assumption that there wouldn't be an ActionTestSummaryGroup with no subtests (since the object only contains duration & subtests) which didn't prove correct in practice.  We now do a flatMap of all the ActionTestSummaryGroup's to get their subtests for iteration rather than trying to go one-by-one with popLast.

I also took this opportunity to add a verbose mode in interactive mode where you can see the commands & JSON responses in order to provide debugging information.

**Test Plan/Testing Performed:** Tested with these changes that I can now get screenshots out of SwiftiumTestingKit when run for multiple devices.
