### PR TITLE
Add attachments sub-command & allow attachment UTI filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Below are a few examples of common commands. For further assistance, use the --h
 ### Screenshots
 
 ```
-xcparse screenshots --os --model --test-run /path/to/Test.xcresult /path/to/exportScreenshots
+xcparse screenshots --os --model --test-run /path/to/Test.xcresult /path/to/outputDirectory
 ```
 
 This will cause screenshots to be exported like so:
@@ -33,11 +33,23 @@ This will cause screenshots to be exported like so:
 
 Options can be added & remove to change the folder structure used for export.  Using no options will lead to all attachments being exported into the output directory.
 
+### Attachments
+
+```
+xcparse attachments /path/to/Test.xcresult /path/to/outputDirectory --uti public.plain-text public.image
+```
+
+Export all attachments in the xcresult that conform to either the ```public.plan-text``` or the ```public.image``` uniform type identifiers (UTI). The screenshots command, for example, is actually just the attachments command operating a whitelist for ```public.image``` UTI attachments.  Other common types in xcresults are ```public.plain-text``` for debug descriptions of test failures.
+
+Read [this Apple documentation]((https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html#//apple_ref/doc/uid/TP40009259-SW1)) for a list of publicly documented UTIs.
+
 ### Code Coverage
 
 ```
 xcparse codecov /path/to/Test.xcresult /path/to/exportCodeCoverageFiles
 ```
+
+This will export the action.xccovreport & action.xccovarchive into your output directory.
 
 ### Logs
 
@@ -52,6 +64,8 @@ xcparse --help
 
 xcparse screenshots --help
 ```
+
+Learn about all the options we didn't mention with ```--help```!
 
 ## Modes
 

--- a/Sources/XCParseCore/ActionTestAttachment.swift
+++ b/Sources/XCParseCore/ActionTestAttachment.swift
@@ -9,13 +9,7 @@
 import Foundation
 
 open class ActionTestAttachment : Codable {
-    enum UniformTypeIdentifier: String {
-        case jpeg = "public.jpeg"
-        case png = "public.png"
-        case txt = "public.plain-text"
-    }
-
-    public let uniformTypeIdentifier: String
+    public let uniformTypeIdentifier: String // Note: You'll want to use CoreServices' UTType functions with this
     public let name: String?
     public let timestamp: Date?
 //    public let userInfo: SortedKeyValueArray?

--- a/Sources/xcparse/CommandRegistry.swift
+++ b/Sources/xcparse/CommandRegistry.swift
@@ -62,8 +62,12 @@ struct CommandRegistry {
             let xcpParser = XCPParser()
             let options = AttachmentExportOptions(addTestScreenshotsDirectory: true,
                                                   divideByTargetModel: false,
-                                                  divideByTargetOS: false)
-            try xcpParser.extractScreenshots(xcresultPath: legacyScreenshotPaths[0].path.pathString,
+                                                  divideByTargetOS: false,
+                                                  divideByTestRun: false,
+                                                  attachmentFilter: {
+                                                    return UTTypeConformsTo($0.uniformTypeIdentifier as CFString, "public.image" as CFString)
+            })
+            try xcpParser.extractAttachments(xcresultPath: legacyScreenshotPaths[0].path.pathString,
                                              destination: legacyScreenshotPaths[1].path.pathString,
                                              options: options)
 

--- a/xcparse.xcodeproj/project.pbxproj
+++ b/xcparse.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		62CC363E23553EA0003C7B68 /* XCResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CC363D23553EA0003C7B68 /* XCResult.swift */; };
+		62CC36592357C110003C7B68 /* AttachmentsCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CC36582357C110003C7B68 /* AttachmentsCommand.swift */; };
 		OBJ_179 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_73 /* Await.swift */; };
 		OBJ_180 /* ByteString.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_74 /* ByteString.swift */; };
 		OBJ_181 /* CStringArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_75 /* CStringArray.swift */; };
@@ -316,10 +317,18 @@
 			remoteGlobalIDString = "SwiftPM::clibc";
 			remoteInfo = clibc;
 		};
+		62CC365723569927003C7B68 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "xcparse::xcparseTests";
+			remoteInfo = xcparseTests;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		62CC363D23553EA0003C7B68 /* XCResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCResult.swift; sourceTree = "<group>"; };
+		62CC36582357C110003C7B68 /* AttachmentsCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentsCommand.swift; sourceTree = "<group>"; };
 		OBJ_10 /* ActionDeviceRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionDeviceRecord.swift; sourceTree = "<group>"; };
 		OBJ_100 /* ProcessEnv.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessEnv.swift; sourceTree = "<group>"; };
 		OBJ_101 /* ProcessSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessSet.swift; sourceTree = "<group>"; };
@@ -742,7 +751,7 @@
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -755,7 +764,6 @@
 				OBJ_172 /* Makefile */,
 				OBJ_173 /* README.md */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_56 /* xcparse */ = {
@@ -766,6 +774,7 @@
 				OBJ_59 /* CommandRegistry.swift */,
 				OBJ_60 /* GitHubLatestReleaseResponse.swift */,
 				OBJ_61 /* LogsCommand.swift */,
+				62CC36582357C110003C7B68 /* AttachmentsCommand.swift */,
 				OBJ_62 /* ScreenshotsCommand.swift */,
 				OBJ_63 /* VersionCommand.swift */,
 				OBJ_64 /* XCPParser.swift */,
@@ -1123,7 +1132,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_162 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1306,6 +1315,7 @@
 				OBJ_347 /* Command.swift in Sources */,
 				OBJ_348 /* CommandRegistry.swift in Sources */,
 				OBJ_349 /* GitHubLatestReleaseResponse.swift in Sources */,
+				62CC36592357C110003C7B68 /* AttachmentsCommand.swift in Sources */,
 				OBJ_350 /* LogsCommand.swift in Sources */,
 				OBJ_351 /* ScreenshotsCommand.swift in Sources */,
 				OBJ_352 /* VersionCommand.swift in Sources */,
@@ -1412,7 +1422,7 @@
 		OBJ_376 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "xcparse::xcparseTests" /* xcparseTests */;
-			targetProxy = "xcparse::xcparseTests" /* xcparseTests */;
+			targetProxy = 62CC365723569927003C7B68 /* PBXContainerItemProxy */;
 		};
 		OBJ_390 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;


### PR DESCRIPTION
**Change Description:** These changes add a new "attachments" sub-command.  This command will by default export all attachments in the xcresult regardless of uniform type identifier (what screenshots used to be doing).  Users can provide a list of UTIs to filter with (ex. "--uti public.plain-text") to only export attachments which conform to the given UTI.  This would be useful for folks who want to get all the debug descriptions, for example.

The screenshots command has bee modified so that it'll only export image attachments & not other files such as text debug descriptions from test failures.  It does this by taking advantage of the UTI filtering & using "public.image" UTI.

**Test Plan/Testing Performed:** Tested that with these changes, I can now export attachments that conform to plain text or image UTIs and avoid exporting everything.
