### PR TITLE
Allow division by test & filtering based off test status & attachment activity type

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,57 @@ This will cause screenshots to be exported like so:
 
 Options can be added & remove to change the folder structure used for export.  Using no options will lead to all attachments being exported into the output directory.
 
+Options available include:
+
+| Option           | Description                             |
+|------------------|-----------------------------------------|
+| ```--model```    | Divide by test target model             | 
+| ```--os```       | Divide by test target operating system  | 
+| ```--test-run``` | Divide by test run configuration        |
+| ```--test```     | Divide by test                          |
+
+See ```xcparse screenshots --help``` for a full-listing
+
+#### Test Status
+
+The ```--test-status``` option can allow for whitelisting only screenshots from tests that have a status that matches at least one of the provided status strings
+
+| Examples         | Description                             |
+|------------------|-----------------------------------------|
+| ```--test-status Success```         | Passing tests only             | 
+| ```--test-status Failure```         | Failing tests only             | 
+| ```--test-status Success Failure``` | Passing or failing tests only  |
+
+
+Test status strings can be found by using verbose mode with the screenshots sub-command.
+
+#### Activity Type
+
+The ```--activity-type``` option allows for whitelisting screenshots whose activity type matches at least one of the provided activity type strings.
+
+| Examples         | Description                             |
+|------------------|-----------------------------------------|
+| ```--activity-type com.apple.dt.xctest.activity-type.testAssertionFailure```| Test failure screenshots only | 
+| ```--activity-type attachmentContainer userCreated```                       | User created screenshots only | 
+
+Note that when an activity type string is provided which doesn't have a reverse-DNS style domain, it is assumed to be of ```com.apple.dt.xctest.activity-type.<activityTypeString>``` and the domain is automatically added.
+
+Therefore, these two are option calls are equivalent:
+
+```--activity-type userCreated attachmentContainer```
+
+```--activity-type com.apple.dt.xctest.activity-type.userCreated com.apple.dt.xctest.activity-type.attachmentContainer```
+
+Activity types can be found in verbose mode.  Below are a listing of common ones:
+
+| Activity Type         | Description                             |
+|------------------|-----------------------------------------|
+| com.apple.dt.xctest.activity-type.attachmentContainer| Placeholder activity that contains an attachment, may contain user created screenshot | 
+| com.apple.dt.xctest.activity-type.deletedAttachment | Deleted attachment placeholder activity |
+| com.apple.dt.xctest.activity-type.internal | Internal test step, may have automatic screenshot to show test progression |
+| com.apple.dt.xctest.activity-type.testAssertionFailure | Step where the test failed in an assertion, may have failure screenshot |
+| com.apple.dt.xctest.activity-type.userCreated | User created screenshot/attachment |
+
 ### Attachments
 
 ```

--- a/Sources/XCParseCore/ActionTestActivitySummary.swift
+++ b/Sources/XCParseCore/ActionTestActivitySummary.swift
@@ -8,6 +8,14 @@
 
 import Foundation
 
+public enum ActionTestActivityType : String {
+    case attachmentContainer = "com.apple.dt.xctest.activity-type.attachmentContainer"
+    case deletedAttachment = "com.apple.dt.xctest.activity-type.deletedAttachment"
+    case `internal` = "com.apple.dt.xctest.activity-type.internal"
+    case testAssertionFailure = "com.apple.dt.xctest.activity-type.testAssertionFailure"
+    case userCreated = "com.apple.dt.xctest.activity-type.userCreated"
+}
+
 open class ActionTestActivitySummary : Codable {
     public let title: String
     public let activityType: String

--- a/Sources/XCParseCore/ActionTestAttachment.swift
+++ b/Sources/XCParseCore/ActionTestAttachment.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 
+public enum ActionTestAttachmentLifetime : String {
+    case keepAlways
+    case deleteOnSuccess
+}
+
 open class ActionTestAttachment : Codable {
     public let uniformTypeIdentifier: String // Note: You'll want to use CoreServices' UTType functions with this
     public let name: String?

--- a/Sources/XCParseCore/ActionTestSummary.swift
+++ b/Sources/XCParseCore/ActionTestSummary.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 
+public enum TestStatus : String {
+    case Success
+    case Failure
+}
+
 open class ActionTestSummary : ActionTestSummaryIdentifiableObject {
     public let testStatus: String
     public let duration: Double

--- a/Sources/XCParseCore/ActionTestSummary.swift
+++ b/Sources/XCParseCore/ActionTestSummary.swift
@@ -35,7 +35,7 @@ open class ActionTestSummary : ActionTestSummaryIdentifiableObject {
         try super.init(from: decoder)
     }
 
-    public func attachments(filterActivitySummaries: (ActionTestActivitySummary) -> Bool = { _ in return true }) -> [ActionTestAttachment] {
+    public func allChildActivitySummaries() -> [ActionTestActivitySummary] {
         var activitySummaries = self.activitySummaries
 
         var summariesToCheck = activitySummaries
@@ -46,7 +46,6 @@ open class ActionTestSummary : ActionTestSummaryIdentifiableObject {
             activitySummaries.append(contentsOf: summariesToCheck)
         } while summariesToCheck.count > 0
 
-        let filteredActivitySummaries = activitySummaries.filter(filterActivitySummaries)
-        return filteredActivitySummaries.flatMap { $0.attachments }
+        return activitySummaries
     }
 }

--- a/Sources/XCParseCore/ActionTestSummary.swift
+++ b/Sources/XCParseCore/ActionTestSummary.swift
@@ -35,7 +35,7 @@ open class ActionTestSummary : ActionTestSummaryIdentifiableObject {
         try super.init(from: decoder)
     }
 
-    public func attachments() -> [ActionTestAttachment] {
+    public func attachments(filterActivitySummaries: (ActionTestActivitySummary) -> Bool = { _ in return true }) -> [ActionTestAttachment] {
         var activitySummaries = self.activitySummaries
 
         var summariesToCheck = activitySummaries
@@ -46,6 +46,7 @@ open class ActionTestSummary : ActionTestSummaryIdentifiableObject {
             activitySummaries.append(contentsOf: summariesToCheck)
         } while summariesToCheck.count > 0
 
-        return activitySummaries.flatMap { $0.attachments }
+        let filteredActivitySummaries = activitySummaries.filter(filterActivitySummaries)
+        return filteredActivitySummaries.flatMap { $0.attachments }
     }
 }

--- a/Sources/XCParseCore/ActionTestableSummary.swift
+++ b/Sources/XCParseCore/ActionTestableSummary.swift
@@ -47,8 +47,8 @@ open class ActionTestableSummary : ActionAbstractTestSummary {
         try super.init(from: decoder)
     }
 
-    public func attachments(withXCResult xcresult: XCResult, filterActivitySummaries: (ActionTestActivitySummary) -> Bool = { _ in return true }) -> [ActionTestAttachment] {
-        var attachments: [ActionTestAttachment] = []
+    public func flattenedTestSummaryMap(withXCResult xcresult: XCResult) -> [(testSummary: ActionTestSummary, activitySummaries: [ActionTestActivitySummary])] {
+        var testSummaryMap: [(ActionTestSummary, [ActionTestActivitySummary])] = []
 
         var tests: [ActionTestSummaryIdentifiableObject] = self.tests
 
@@ -86,35 +86,22 @@ open class ActionTestableSummary : ActionAbstractTestSummary {
             tests = summaryGroups.flatMap { $0.subtests }
         } while tests.count > 0
 
-        // Need to extract out the testSummary until get all ActionTestActivitySummary
-        var activitySummaries = testSummaries.flatMap { $0.activitySummaries }
+        // For those where we already have the ActionTestSummary, add them to the map
+        let testSummariesToAllChildActivities = testSummaries.map { (testSummary: $0, activitySummaries: $0.allChildActivitySummaries()) }
+        testSummaryMap.append(contentsOf: testSummariesToAllChildActivities)
 
-        // Get all subactivities
-        var summariesToCheck = activitySummaries
-        repeat {
-            summariesToCheck = summariesToCheck.flatMap { $0.subactivities }
-
-            // Add the subactivities we found
-            activitySummaries.append(contentsOf: summariesToCheck)
-        } while summariesToCheck.count > 0
-
-        // Filter the ActionTestActivitySummary array for the ones we want
-        activitySummaries = activitySummaries.filter(filterActivitySummaries)
-
-        for activitySummary in activitySummaries {
-            let summaryAttachments = activitySummary.attachments
-            attachments.append(contentsOf: summaryAttachments)
-        }
-
+        // Now let's go digging out the ActionTestSummary from these ActionTestMetadata references we got (will involve more xcresulttool calls)
         let testSummaryReferences = testMetadata.compactMap { $0.summaryRef }
         for summaryReference in testSummaryReferences {
             guard let summary: ActionTestSummary = summaryReference.modelFromReference(withXCResult: xcresult) else {
                 xcresult.console.writeMessage("Error: Unhandled test summary type \(String(describing: summaryReference.targetType?.getType()))", to: .error)
                 continue
             }
-            attachments.append(contentsOf: summary.attachments(filterActivitySummaries: filterActivitySummaries))
+
+            let referenceSummaryChildActivities = summary.allChildActivitySummaries()
+            testSummaryMap.append((summary, referenceSummaryChildActivities))
         }
 
-        return attachments
+        return testSummaryMap
     }
 }

--- a/Sources/XCParseCore/ActionTestableSummary.swift
+++ b/Sources/XCParseCore/ActionTestableSummary.swift
@@ -47,7 +47,7 @@ open class ActionTestableSummary : ActionAbstractTestSummary {
         try super.init(from: decoder)
     }
 
-    public func attachments(withXCResult xcresult: XCResult) -> [ActionTestAttachment] {
+    public func attachments(withXCResult xcresult: XCResult, filterActivitySummaries: (ActionTestActivitySummary) -> Bool = { _ in return true }) -> [ActionTestAttachment] {
         var attachments: [ActionTestAttachment] = []
 
         var tests: [ActionTestSummaryIdentifiableObject] = self.tests
@@ -98,6 +98,9 @@ open class ActionTestableSummary : ActionAbstractTestSummary {
             activitySummaries.append(contentsOf: summariesToCheck)
         } while summariesToCheck.count > 0
 
+        // Filter the ActionTestActivitySummary array for the ones we want
+        activitySummaries = activitySummaries.filter(filterActivitySummaries)
+
         for activitySummary in activitySummaries {
             let summaryAttachments = activitySummary.attachments
             attachments.append(contentsOf: summaryAttachments)
@@ -109,7 +112,7 @@ open class ActionTestableSummary : ActionAbstractTestSummary {
                 xcresult.console.writeMessage("Error: Unhandled test summary type \(String(describing: summaryReference.targetType?.getType()))", to: .error)
                 continue
             }
-            attachments.append(contentsOf: summary.attachments())
+            attachments.append(contentsOf: summary.attachments(filterActivitySummaries: filterActivitySummaries))
         }
 
         return attachments

--- a/Sources/xcparse/AttachmentsCommand.swift
+++ b/Sources/xcparse/AttachmentsCommand.swift
@@ -22,6 +22,7 @@ struct AttachmentsCommand: Command {
     var divideByModel: OptionArgument<Bool>
     var divideByOS: OptionArgument<Bool>
     var divideByTestPlanRun: OptionArgument<Bool>
+    var divideByTest: OptionArgument<Bool>
 
     var utiWhitelist: OptionArgument<[String]>
     var activityType: OptionArgument<[String]>
@@ -37,6 +38,7 @@ struct AttachmentsCommand: Command {
         divideByModel = subparser.add(option: "--model", shortName: nil, kind: Bool.self, usage: "Divide attachments by model")
         divideByOS = subparser.add(option: "--os", shortName: nil, kind: Bool.self, usage: "Divide attachments by OS")
         divideByTestPlanRun = subparser.add(option: "--test-run", shortName: nil, kind: Bool.self, usage: "Divide attachments by test plan configuration")
+        divideByTest = subparser.add(option: "--test", shortName: nil, kind: Bool.self, usage: "Divide attachments by test")
 
         utiWhitelist = subparser.add(option: "--uti", shortName: nil, kind: [String].self, strategy: .upToNextOption,
                                      usage: "Takes list of uniform type identifiers (UTI) and export only attachments that conform to at least one")
@@ -70,7 +72,8 @@ struct AttachmentsCommand: Command {
         var options = AttachmentExportOptions(addTestScreenshotsDirectory: false,
                                               divideByTargetModel: arguments.get(self.divideByModel) ?? false,
                                               divideByTargetOS: arguments.get(self.divideByOS) ?? false,
-                                              divideByTestRun: arguments.get(self.divideByTestPlanRun) ?? false)
+                                              divideByTestRun: arguments.get(self.divideByTestPlanRun) ?? false,
+                                              divideByTest: arguments.get(self.divideByTest) ?? false)
         if let allowedUTIsToExport = arguments.get(self.utiWhitelist) {
             options.attachmentFilter = {
                 let attachmentUTI = $0.uniformTypeIdentifier as CFString

--- a/Sources/xcparse/ScreenshotsCommand.swift
+++ b/Sources/xcparse/ScreenshotsCommand.swift
@@ -25,6 +25,10 @@ struct ScreenshotsCommand: Command {
     var divideByTestPlanRun: OptionArgument<Bool>
     var divideByTest: OptionArgument<Bool>
 
+    var excludePassingTests: OptionArgument<Bool>
+    var excludeFailingTests: OptionArgument<Bool>
+    var excludeAutomaticScreenshots: OptionArgument<Bool>
+
     init(parser: ArgumentParser) {
         let subparser = parser.add(subparser: command, usage: usage, overview: overview)
         path = subparser.add(positional: "xcresult", kind: PathArgument.self,
@@ -37,7 +41,11 @@ struct ScreenshotsCommand: Command {
         divideByModel = subparser.add(option: "--model", shortName: nil, kind: Bool.self, usage: "Divide screenshots by model")
         divideByOS = subparser.add(option: "--os", shortName: nil, kind: Bool.self, usage: "Divide screenshots by OS")
         divideByTestPlanRun = subparser.add(option: "--test-run", shortName: nil, kind: Bool.self, usage: "Divide screenshots by test plan configuration")
-        divideByTest = subparser.add(option: "--test", shortName: nil, kind: Bool.self, usage: "Divide attachments by test")
+        divideByTest = subparser.add(option: "--test", shortName: nil, kind: Bool.self, usage: "Divide screenshots by test")
+
+        excludePassingTests = subparser.add(option: "--exclude-passing-tests", shortName: nil, kind: Bool.self, usage: "Exclude screenshots from passing tests")
+        excludeFailingTests = subparser.add(option: "--exclude-failing-tests", shortName: nil, kind: Bool.self, usage: "Exclude screenshots from failing tests")
+        excludeAutomaticScreenshots = subparser.add(option: "--exclude-automatic", shortName: nil, kind: Bool.self, usage: "Exclude automatic screenshots")
     }
 
     func run(with arguments: ArgumentParser.Result) throws {
@@ -67,6 +75,9 @@ struct ScreenshotsCommand: Command {
                                               divideByTargetOS: arguments.get(self.divideByOS) ?? false,
                                               divideByTestRun: arguments.get(self.divideByTestPlanRun) ?? false,
                                               divideByTest: arguments.get(self.divideByTest) ?? false,
+                                              excludePassingTests: arguments.get(self.excludePassingTests) ?? false,
+                                              excludeFailingTests: arguments.get(self.excludeFailingTests) ?? false,
+                                              excludeAutomaticScreenshots: arguments.get(self.excludeAutomaticScreenshots) ?? false,
                                               attachmentFilter: {
                                                 return UTTypeConformsTo($0.uniformTypeIdentifier as CFString, "public.image" as CFString)
         })

--- a/Sources/xcparse/ScreenshotsCommand.swift
+++ b/Sources/xcparse/ScreenshotsCommand.swift
@@ -23,6 +23,7 @@ struct ScreenshotsCommand: Command {
     var divideByModel: OptionArgument<Bool>
     var divideByOS: OptionArgument<Bool>
     var divideByTestPlanRun: OptionArgument<Bool>
+    var divideByTest: OptionArgument<Bool>
 
     init(parser: ArgumentParser) {
         let subparser = parser.add(subparser: command, usage: usage, overview: overview)
@@ -36,6 +37,7 @@ struct ScreenshotsCommand: Command {
         divideByModel = subparser.add(option: "--model", shortName: nil, kind: Bool.self, usage: "Divide screenshots by model")
         divideByOS = subparser.add(option: "--os", shortName: nil, kind: Bool.self, usage: "Divide screenshots by OS")
         divideByTestPlanRun = subparser.add(option: "--test-run", shortName: nil, kind: Bool.self, usage: "Divide screenshots by test plan configuration")
+        divideByTest = subparser.add(option: "--test", shortName: nil, kind: Bool.self, usage: "Divide attachments by test")
     }
 
     func run(with arguments: ArgumentParser.Result) throws {
@@ -64,6 +66,7 @@ struct ScreenshotsCommand: Command {
                                               divideByTargetModel: arguments.get(self.divideByModel) ?? false,
                                               divideByTargetOS: arguments.get(self.divideByOS) ?? false,
                                               divideByTestRun: arguments.get(self.divideByTestPlanRun) ?? false,
+                                              divideByTest: arguments.get(self.divideByTest) ?? false,
                                               attachmentFilter: {
                                                 return UTTypeConformsTo($0.uniformTypeIdentifier as CFString, "public.image" as CFString)
         })

--- a/Sources/xcparse/ScreenshotsCommand.swift
+++ b/Sources/xcparse/ScreenshotsCommand.swift
@@ -25,9 +25,8 @@ struct ScreenshotsCommand: Command {
     var divideByTestPlanRun: OptionArgument<Bool>
     var divideByTest: OptionArgument<Bool>
 
-    var excludePassingTests: OptionArgument<Bool>
-    var excludeFailingTests: OptionArgument<Bool>
-    var excludeAutomaticScreenshots: OptionArgument<Bool>
+    var testStatusWhitelist: OptionArgument<[String]>
+    var activityTypeWhitelist: OptionArgument<[String]>
 
     init(parser: ArgumentParser) {
         let subparser = parser.add(subparser: command, usage: usage, overview: overview)
@@ -43,9 +42,10 @@ struct ScreenshotsCommand: Command {
         divideByTestPlanRun = subparser.add(option: "--test-run", shortName: nil, kind: Bool.self, usage: "Divide screenshots by test plan configuration")
         divideByTest = subparser.add(option: "--test", shortName: nil, kind: Bool.self, usage: "Divide screenshots by test")
 
-        excludePassingTests = subparser.add(option: "--exclude-passing-tests", shortName: nil, kind: Bool.self, usage: "Exclude screenshots from passing tests")
-        excludeFailingTests = subparser.add(option: "--exclude-failing-tests", shortName: nil, kind: Bool.self, usage: "Exclude screenshots from failing tests")
-        excludeAutomaticScreenshots = subparser.add(option: "--exclude-automatic", shortName: nil, kind: Bool.self, usage: "Exclude automatic screenshots")
+        testStatusWhitelist = subparser.add(option: "--test-status", shortName: nil, kind: [String].self, strategy: .upToNextOption,
+                                            usage: "Whitelist of acceptable test statuses for screenshots [optional, example: \"--test-status Success Failure\"]")
+        activityTypeWhitelist = subparser.add(option: "--activity-type", shortName: nil, kind: [String].self, strategy: .upToNextOption,
+                                              usage: "Whitelist of acceptable activity types for screenshots. If value does not specify domain, \"com.apple.dt.xctest.activity-type.\" is assumed and prefixed to the value [optional, example: \"--activity-type userCreated attachmentContainer com.apple.dt.xctest.activity-type.testAssertionFailure\"]")
     }
 
     func run(with arguments: ArgumentParser.Result) throws {
@@ -70,17 +70,29 @@ struct ScreenshotsCommand: Command {
         let xcpParser = XCPParser()
         xcpParser.console.verbose = verbose
 
-        let options = AttachmentExportOptions(addTestScreenshotsDirectory: arguments.get(self.addTestScreenshotDirectory) ?? false,
+        var options = AttachmentExportOptions(addTestScreenshotsDirectory: arguments.get(self.addTestScreenshotDirectory) ?? false,
                                               divideByTargetModel: arguments.get(self.divideByModel) ?? false,
                                               divideByTargetOS: arguments.get(self.divideByOS) ?? false,
                                               divideByTestRun: arguments.get(self.divideByTestPlanRun) ?? false,
                                               divideByTest: arguments.get(self.divideByTest) ?? false,
-                                              excludePassingTests: arguments.get(self.excludePassingTests) ?? false,
-                                              excludeFailingTests: arguments.get(self.excludeFailingTests) ?? false,
-                                              excludeAutomaticScreenshots: arguments.get(self.excludeAutomaticScreenshots) ?? false,
                                               attachmentFilter: {
                                                 return UTTypeConformsTo($0.uniformTypeIdentifier as CFString, "public.image" as CFString)
         })
+        if let allowedTestStatuses = arguments.get(self.testStatusWhitelist) {
+            options.testSummaryFilter = { allowedTestStatuses.contains($0.testStatus) }
+        }
+        if let allowedActivityTypes = arguments.get(self.activityTypeWhitelist) {
+            // Writing the full domain can be exhausting, so if there is no domain specified, assume it was the normal activity type domain
+            var additionalActivityTypes: [String] = allowedActivityTypes
+
+            let activityTypesWithoutDomain = allowedActivityTypes.filter { $0.contains(Character(".")) == false }
+            for activityType in activityTypesWithoutDomain {
+                additionalActivityTypes.append("com.apple.dt.xctest.activity-type." + activityType)
+            }
+
+            options.activitySummaryFilter = { additionalActivityTypes.contains($0.activityType) }
+        }
+
         try xcpParser.extractAttachments(xcresultPath: xcresultPath.pathString,
                                          destination: outputPath.pathString,
                                          options: options)

--- a/Sources/xcparse/XCPParser.swift
+++ b/Sources/xcparse/XCPParser.swift
@@ -78,14 +78,13 @@ struct AttachmentExportOptions {
     var divideByTestRun: Bool = false
     var divideByTest: Bool = false
 
-    var excludePassingTests: Bool = false
-    var excludeFailingTests: Bool = false
-    var excludeAutomaticScreenshots: Bool = false
-
-    var attachmentFilter: (ActionTestAttachment) -> Bool = { _ in
+    var testSummaryFilter: (ActionTestSummary) -> Bool = { _ in
         return true
     }
     var activitySummaryFilter: (ActionTestActivitySummary) -> Bool = { _ in
+        return true
+    }
+    var attachmentFilter: (ActionTestAttachment) -> Bool = { _ in
         return true
     }
 
@@ -194,9 +193,7 @@ class XCPParser {
                 let testableSummaries = testPlanRun.testableSummaries
                 let testableSummariesToTestActivity = testableSummaries.flatMap { $0.flattenedTestSummaryMap(withXCResult: xcresult) }
                 for (testableSummary, childActivitySummaries) in testableSummariesToTestActivity {
-                    if options.excludePassingTests == true, testableSummary.testStatus == TestStatus.Success.rawValue {
-                        continue
-                    } else if options.excludeFailingTests == true, testableSummary.testStatus == TestStatus.Failure.rawValue {
+                    if options.testSummaryFilter(testableSummary) == false {
                         continue
                     }
 

--- a/Sources/xcparse/XCPParser.swift
+++ b/Sources/xcparse/XCPParser.swift
@@ -76,6 +76,9 @@ struct AttachmentExportOptions {
     var attachmentFilter: (ActionTestAttachment) -> Bool = { _ in
         return true
     }
+    var activitySummaryFilter: (ActionTestActivitySummary) -> Bool = { _ in
+        return true
+    }
 
     func baseScreenshotDirectoryURL(path: String) -> Foundation.URL {
         let destinationURL = URL.init(fileURLWithPath: path)
@@ -168,12 +171,14 @@ class XCPParser {
                 }
 
                 let testableSummaries = testPlanRun.testableSummaries
-                let testableSummariesAttachments = testableSummaries.flatMap { $0.attachments(withXCResult: xcresult) }.filter(options.attachmentFilter)
+                let testableSummariesAttachments = testableSummaries.flatMap { $0.attachments(withXCResult: xcresult,
+                                                                                              filterActivitySummaries: options.activitySummaryFilter) }
+                let filteredTestableSummariesAttachments = testableSummariesAttachments.filter(options.attachmentFilter)
 
                 // Now that we know what we want to export, save it to the dictionary so we can have all the exports
                 // done at once with one progress bar per URL
                 var existingAttachmentsForBaseURL = exportURLsToAttachments[testPlanRunScreenshotURL.path] ?? []
-                existingAttachmentsForBaseURL.append(contentsOf: testableSummariesAttachments)
+                existingAttachmentsForBaseURL.append(contentsOf: filteredTestableSummariesAttachments)
                 exportURLsToAttachments[testPlanRunScreenshotURL.path] = existingAttachmentsForBaseURL
             }
         }


### PR DESCRIPTION
**Change Description:** These changes introduce a new option to the screenshots/attachments sub-commands of "--test" to allow for division of screenshots on an individual test status.  This allows for much nicer file structure review where screenshots from the same test can be easily seen together.  Additionally, "--activity-type" & "--test-status" have been added as additional options to allow for advanced users to filter out screenshots from failing tests (or vice versa), or get only the screenshots that the test failure asserted via the activity type of the attachment.  These are whitelists and allow for folks to figure out all the activity types they care about rather than hard-defining the rules in xcparse.

**Test Plan/Testing Performed:** Done some basic testing, but need to do a bit more.
