### PR TITLE
Remove interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,16 +117,3 @@ xcparse screenshots --help
 ```
 
 Learn about all the options we didn't mention with ```--help```!
-
-## Modes
-
-### Static Mode
-This is the default mode in which xcparse runs if the user specifies a command & arguments.
-
-### Interactive Mode
-When the user runs xcparse with no arguments, xcparse runs in interactive mode. In this mode the user is prompted to enter commands and arguments as required.
-
-## Useful Commands
-
-1. brew untap - Untaps from specified homebrew tap
-2. brew uninstall - Uninstall homebrew tool

--- a/Sources/xcparse/XCPParser.swift
+++ b/Sources/xcparse/XCPParser.swift
@@ -11,29 +11,7 @@ import Foundation
 import SPMUtility
 import XCParseCore
 
-let xcparseCurrentVersion = Version(0, 7, 0)
-
-enum InteractiveModeOptionType: String {
-    case screenshot = "s"
-    case log = "l"
-    case xcov = "x"
-    case verbose = "v"
-    case help = "h"
-    case quit = "q"
-    case unknown
-  
-    init(value: String) {
-        switch value {
-            case "s", "screenshots": self = .screenshot
-            case "l", "logs": self = .log
-            case "x", "xcov": self = .xcov
-            case "v", "verbose": self = .verbose
-            case "h", "help": self = .help
-            case "q", "quit": self = .quit
-            default: self = .unknown
-        }
-    }
-}
+let xcparseCurrentVersion = Version(1, 0, 0)
 
 extension Foundation.URL {
     func fileExistsAsDirectory() -> Bool {
@@ -356,55 +334,4 @@ class XCPParser {
 
         self.printLatestVersionInfoIfNeeded()
     }
-
-    func getInteractiveModeOption(_ option: String) -> (option: InteractiveModeOptionType, value: String) {
-      return (InteractiveModeOptionType(value: option), option)
-    }
-    
-    func interactiveMode() throws {
-        checkVersion()
-        console.writeMessage("Welcome to xcparse \(xcparseCurrentVersion). This program can extract screenshots and coverage files from an *.xcresult file.")
-
-        var shouldQuit = false
-        while !shouldQuit {
-            self.printLatestVersionInfoIfNeeded()
-
-            console.writeMessage("Type 's' to extract screenshots, 'l' for logs, 'x' for code coverage files, 'v' for verbose, 'h' for help, or 'q' to quit.")
-
-            let (option, value) = getInteractiveModeOption(console.getInput())
-
-            switch option {
-            case .screenshot:
-                console.writeMessage("Type the path to your *.xcresult file:")
-                let path = console.getInput()
-                console.writeMessage("Type the path to the destination folder for your screenshots:")
-                let destinationPath = console.getInput()
-                try extractAttachments(xcresultPath: path, destination: destinationPath)
-            case .log:
-                console.writeMessage("Type the path to your *.xcresult file:")
-                let path = console.getInput()
-                console.writeMessage("Type the path to the destination folder for your logs:")
-                let destinationPath = console.getInput()
-                try extractLogs(xcresultPath: path, destination: destinationPath)
-            case .xcov:
-                console.writeMessage("Type the path to your *.xcresult file:")
-                let path = console.getInput()
-                console.writeMessage("Type the path to the destination folder for your coverage file:")
-                let destinationPath = console.getInput()
-                try extractCoverage(xcresultPath: path, destination: destinationPath)
-            case .verbose:
-                console.verbose = true
-                console.writeMessage("Verbose mode enabled")
-            case .quit:
-                shouldQuit = true
-            case .help:
-                console.printInteractiveUsage()
-            default:
-                console.writeMessage("Unknown option \(value)", to: .error)
-                console.printInteractiveUsage()
-            }
-        }
-    }
-    
-    
 }

--- a/Sources/xcparse/main.swift
+++ b/Sources/xcparse/main.swift
@@ -13,9 +13,8 @@ import Foundation
 // MARK: Main
 
 let parser = XCPParser()
-if CommandLine.argc < 2 {
-    try parser.interactiveMode()
-} else {
+do {
     try parser.staticMode()
+} catch {
+    print("Error: \(error)")
 }
-


### PR DESCRIPTION
**Change Description:** We're now at a point where interactive mode is currently more work to keep around than it is likely worth.  As part of version 1, we're going to remove the mode now that we allow for multiple options & a highly usable --help command for the various sub-commands and compatible options.

**Test Plan/Testing Performed:** Tested that with these changes, calling the old interactive mode now leads to the help usage being printed.