### PR TITLE
Added numbering to the filenames of the attachments that are extracted

### DIFF
--- a/Sources/XCParseCore/XCResultToolCommand.swift
+++ b/Sources/XCParseCore/XCResultToolCommand.swift
@@ -80,12 +80,12 @@ open class XCResultToolCommand {
             super.init(withXCResult: xcresult, process: process)
         }
 
-        public init(withXCResult xcresult: XCResult, attachment: ActionTestAttachment, outputPath: String) {
+        public init(withXCResult xcresult: XCResult, attachment: ActionTestAttachment, outputPath: String, filenamePrefix: String = "") {
             if let identifier = attachment.payloadRef?.id {
                 self.id = identifier;
 
                 // Now let's figure out the filename & path
-                let filename = attachment.filename ?? identifier
+                let filename = filenamePrefix + "\(attachment.filename ?? identifier)"
                 let attachmentOutputPath = URL.init(fileURLWithPath: outputPath).appendingPathComponent(filename)
                 self.outputPath = attachmentOutputPath.path
             }

--- a/Sources/xcparse/XCPParser.swift
+++ b/Sources/xcparse/XCPParser.swift
@@ -326,7 +326,7 @@ class XCPParser {
         for (index, attachment) in attachments.enumerated() {
             progressBar.update(step: index, total: attachments.count, text: "Extracting \"\(attachment.filename ?? "Unknown Filename")\"")
 
-            XCResultToolCommand.Export(withXCResult: xcresult, attachment: attachment, outputPath: screenshotDirectoryURL.path).run()
+            XCResultToolCommand.Export(withXCResult: xcresult, attachment: attachment, outputPath: screenshotDirectoryURL.path, filenamePrefix: "\(index)-").run()
         }
 
         progressBar.update(step: attachments.count, total: attachments.count, text: "🎊 Export complete! 🎊")


### PR DESCRIPTION
**Change Description:**
Added numbering to the filenames of the attachments that are extracted.
I needed the attachments to be numbered so that I can see the order that the screenshots happened for UI testing and debugging.
**Test Plan/Testing Performed:**
Verified that the numbering of the attachments works by running on several .xcresult files from my own project
