### PR TITLE
Add xcresult 3.26 support

### DIFF
--- a/FormatDescriptions/FormatDescriptions.md
+++ b/FormatDescriptions/FormatDescriptions.md
@@ -1,0 +1,14 @@
+# Supported Format Descriptions
+
+This is where we keep a listing of the format descriptions from xcresultttol that we support. Format descriptions help us to understand what data structures exist in the xcresult format & update for changes in the latest Xcode.
+
+You can use these to analyze what changed between different versions of Xcode & xcresulttool.
+
+## Generate Format Description 
+
+To get the current format description for your Xcode, run the following in Terminal:
+
+```shell
+xcrun xcresulttool formatDescription > ~/Downloads/currentXcodeFormatDescription.txt
+```
+This will create a text file in your Downloads directory that contains the format description that you can then file compare with the descriptions here.

--- a/FormatDescriptions/xcresult-3.24.txt
+++ b/FormatDescriptions/xcresult-3.24.txt
@@ -1,0 +1,361 @@
+Name: Xcode Result Types
+Version: 3.24
+Signature: Q2HMu2bNSLM=
+Types:
+  - ActionAbstractTestSummary
+    * Kind: object
+    * Properties:
+      + name: String?
+  - ActionDeviceRecord
+    * Kind: object
+    * Properties:
+      + name: String
+      + isConcreteDevice: Bool
+      + operatingSystemVersion: String
+      + operatingSystemVersionWithBuildNumber: String
+      + nativeArchitecture: String
+      + modelName: String
+      + modelCode: String
+      + modelUTI: String
+      + identifier: String
+      + isWireless: Bool
+      + cpuKind: String
+      + cpuCount: Int?
+      + cpuSpeedInMHz: Int?
+      + busSpeedInMHz: Int?
+      + ramSizeInMegabytes: Int?
+      + physicalCPUCoresPerPackage: Int?
+      + logicalCPUCoresPerPackage: Int?
+      + platformRecord: ActionPlatformRecord
+  - ActionPlatformRecord
+    * Kind: object
+    * Properties:
+      + identifier: String
+      + userDescription: String
+  - ActionRecord
+    * Kind: object
+    * Properties:
+      + schemeCommandName: String
+      + schemeTaskName: String
+      + title: String?
+      + startedTime: Date
+      + endedTime: Date
+      + runDestination: ActionRunDestinationRecord
+      + buildResult: ActionResult
+      + actionResult: ActionResult
+  - ActionResult
+    * Kind: object
+    * Properties:
+      + resultName: String
+      + status: String
+      + metrics: ResultMetrics
+      + issues: ResultIssueSummaries
+      + coverage: CodeCoverageInfo
+      + timelineRef: Reference?
+      + logRef: Reference?
+      + testsRef: Reference?
+      + diagnosticsRef: Reference?
+  - ActionRunDestinationRecord
+    * Kind: object
+    * Properties:
+      + displayName: String
+      + targetArchitecture: String
+      + targetDeviceRecord: ActionDeviceRecord
+      + localComputerRecord: ActionDeviceRecord
+      + targetSDKRecord: ActionSDKRecord
+  - ActionSDKRecord
+    * Kind: object
+    * Properties:
+      + name: String
+      + identifier: String
+      + operatingSystemVersion: String
+      + isInternal: Bool
+  - ActionTestActivitySummary
+    * Kind: object
+    * Properties:
+      + title: String
+      + activityType: String
+      + uuid: String
+      + start: Date?
+      + finish: Date?
+      + attachments: [ActionTestAttachment]
+      + subactivities: [ActionTestActivitySummary]
+  - ActionTestAttachment
+    * Kind: object
+    * Properties:
+      + uniformTypeIdentifier: String
+      + name: String?
+      + timestamp: Date?
+      + userInfo: SortedKeyValueArray?
+      + lifetime: String
+      + inActivityIdentifier: Int
+      + filename: String?
+      + payloadRef: Reference?
+      + payloadSize: Int
+  - ActionTestFailureSummary
+    * Kind: object
+    * Properties:
+      + message: String?
+      + fileName: String
+      + lineNumber: Int
+      + isPerformanceFailure: Bool
+  - ActionTestMetadata
+    * Supertype: ActionTestSummaryIdentifiableObject
+    * Kind: object
+    * Properties:
+      + testStatus: String
+      + duration: Double?
+      + summaryRef: Reference?
+      + performanceMetricsCount: Int
+      + failureSummariesCount: Int
+      + activitySummariesCount: Int
+  - ActionTestNoticeSummary
+    * Kind: object
+    * Properties:
+      + message: String?
+      + fileName: String
+      + lineNumber: Int
+  - ActionTestPerformanceMetricSummary
+    * Kind: object
+    * Properties:
+      + displayName: String
+      + unitOfMeasurement: String
+      + measurements: [Double]
+      + identifier: String?
+      + baselineName: String?
+      + baselineAverage: Double?
+      + maxPercentRegression: Double?
+      + maxPercentRelativeStandardDeviation: Double?
+      + maxRegression: Double?
+      + maxStandardDeviation: Double?
+  - ActionTestPlanRunSummaries
+    * Kind: object
+    * Properties:
+      + summaries: [ActionTestPlanRunSummary]
+  - ActionTestPlanRunSummary
+    * Supertype: ActionAbstractTestSummary
+    * Kind: object
+    * Properties:
+      + testableSummaries: [ActionTestableSummary]
+  - ActionTestSummary
+    * Supertype: ActionTestSummaryIdentifiableObject
+    * Kind: object
+    * Properties:
+      + testStatus: String
+      + duration: Double
+      + performanceMetrics: [ActionTestPerformanceMetricSummary]
+      + failureSummaries: [ActionTestFailureSummary]
+      + skipNoticeSummary: ActionTestNoticeSummary?
+      + activitySummaries: [ActionTestActivitySummary]
+  - ActionTestSummaryGroup
+    * Supertype: ActionTestSummaryIdentifiableObject
+    * Kind: object
+    * Properties:
+      + duration: Double
+      + subtests: [ActionTestSummaryIdentifiableObject]
+  - ActionTestSummaryIdentifiableObject
+    * Supertype: ActionAbstractTestSummary
+    * Kind: object
+    * Properties:
+      + identifier: String?
+  - ActionTestableSummary
+    * Supertype: ActionAbstractTestSummary
+    * Kind: object
+    * Properties:
+      + projectRelativePath: String?
+      + targetName: String?
+      + testKind: String?
+      + tests: [ActionTestSummaryIdentifiableObject]
+      + diagnosticsDirectoryName: String?
+      + failureSummaries: [ActionTestFailureSummary]
+      + testLanguage: String?
+      + testRegion: String?
+  - ActionsInvocationMetadata
+    * Kind: object
+    * Properties:
+      + creatingWorkspaceFilePath: String
+      + uniqueIdentifier: String
+      + schemeIdentifier: EntityIdentifier?
+  - ActionsInvocationRecord
+    * Kind: object
+    * Properties:
+      + metadataRef: Reference?
+      + metrics: ResultMetrics
+      + issues: ResultIssueSummaries
+      + actions: [ActionRecord]
+      + archive: ArchiveInfo?
+  - ActivityLogAnalyzerControlFlowStep
+    * Supertype: ActivityLogAnalyzerStep
+    * Kind: object
+    * Properties:
+      + title: String
+      + startLocation: DocumentLocation?
+      + endLocation: DocumentLocation?
+      + edges: [ActivityLogAnalyzerControlFlowStepEdge]
+  - ActivityLogAnalyzerControlFlowStepEdge
+    * Kind: object
+    * Properties:
+      + startLocation: DocumentLocation?
+      + endLocation: DocumentLocation?
+  - ActivityLogAnalyzerEventStep
+    * Supertype: ActivityLogAnalyzerStep
+    * Kind: object
+    * Properties:
+      + title: String
+      + location: DocumentLocation?
+      + description: String
+      + callDepth: Int
+  - ActivityLogAnalyzerResultMessage
+    * Supertype: ActivityLogMessage
+    * Kind: object
+    * Properties:
+      + steps: [ActivityLogAnalyzerStep]
+      + resultType: String?
+      + keyEventIndex: Int
+  - ActivityLogAnalyzerStep
+    * Kind: object
+    * Properties:
+      + parentIndex: Int
+  - ActivityLogAnalyzerWarningMessage
+    * Supertype: ActivityLogMessage
+    * Kind: object
+  - ActivityLogCommandInvocationSection
+    * Supertype: ActivityLogSection
+    * Kind: object
+    * Properties:
+      + commandDetails: String
+      + emittedOutput: String
+      + exitCode: Int?
+  - ActivityLogMajorSection
+    * Supertype: ActivityLogSection
+    * Kind: object
+    * Properties:
+      + subtitle: String
+  - ActivityLogMessage
+    * Kind: object
+    * Properties:
+      + type: String
+      + title: String
+      + shortTitle: String?
+      + category: String?
+      + location: DocumentLocation?
+      + annotations: [ActivityLogMessageAnnotation]
+  - ActivityLogMessageAnnotation
+    * Kind: object
+    * Properties:
+      + title: String
+      + location: DocumentLocation?
+  - ActivityLogSection
+    * Kind: object
+    * Properties:
+      + domainType: String
+      + title: String
+      + startTime: Date?
+      + duration: Double
+      + result: String?
+      + location: DocumentLocation?
+      + subsections: [ActivityLogSection]
+      + messages: [ActivityLogMessage]
+  - ActivityLogTargetBuildSection
+    * Supertype: ActivityLogMajorSection
+    * Kind: object
+    * Properties:
+      + productType: String?
+  - ActivityLogUnitTestSection
+    * Supertype: ActivityLogSection
+    * Kind: object
+    * Properties:
+      + testName: String?
+      + suiteName: String?
+      + summary: String?
+      + emittedOutput: String?
+      + performanceTestOutput: String?
+      + testsPassedString: String?
+      + wasSkipped: Bool
+      + runnablePath: String?
+      + runnableUTI: String?
+  - ArchiveInfo
+    * Kind: object
+    * Properties:
+      + path: String?
+  - Array
+    * Kind: array
+  - Bool
+    * Kind: value
+  - CodeCoverageInfo
+    * Kind: object
+    * Properties:
+      + hasCoverageData: Bool
+      + reportRef: Reference?
+      + archiveRef: Reference?
+  - Date
+    * Kind: value
+  - DocumentLocation
+    * Kind: object
+    * Properties:
+      + url: String
+      + concreteTypeName: String
+  - Double
+    * Kind: value
+  - EntityIdentifier
+    * Kind: object
+    * Properties:
+      + entityName: String
+      + containerName: String
+      + entityType: String
+      + sharedState: String
+  - Int
+    * Kind: value
+  - IssueSummary
+    * Kind: object
+    * Properties:
+      + issueType: String
+      + message: String
+      + producingTarget: String?
+      + documentLocationInCreatingWorkspace: DocumentLocation?
+  - ObjectID
+    * Kind: object
+    * Properties:
+      + hash: String
+  - Reference
+    * Kind: object
+    * Properties:
+      + id: String
+      + targetType: TypeDefinition?
+  - ResultIssueSummaries
+    * Kind: object
+    * Properties:
+      + analyzerWarningSummaries: [IssueSummary]
+      + errorSummaries: [IssueSummary]
+      + testFailureSummaries: [TestFailureIssueSummary]
+      + warningSummaries: [IssueSummary]
+  - ResultMetrics
+    * Kind: object
+    * Properties:
+      + analyzerWarningCount: Int
+      + errorCount: Int
+      + testsCount: Int
+      + testsFailedCount: Int
+      + testsSkippedCount: Int
+      + warningCount: Int
+  - SortedKeyValueArray
+    * Kind: object
+    * Properties:
+      + storage: [SortedKeyValueArrayPair]
+  - SortedKeyValueArrayPair
+    * Kind: object
+    * Properties:
+      + key: String
+      + value: SchemaSerializable
+  - String
+    * Kind: value
+  - TestFailureIssueSummary
+    * Supertype: IssueSummary
+    * Kind: object
+    * Properties:
+      + testCaseName: String
+  - TypeDefinition
+    * Kind: object
+    * Properties:
+      + name: String
+      + supertype: TypeDefinition?

--- a/FormatDescriptions/xcresult-3.26.txt
+++ b/FormatDescriptions/xcresult-3.26.txt
@@ -1,0 +1,397 @@
+Name: Xcode Result Types
+Version: 3.26
+Signature: XtEXH3GNNNI=
+Types:
+  - ActionAbstractTestSummary
+    * Kind: object
+    * Properties:
+      + name: String?
+  - ActionDeviceRecord
+    * Kind: object
+    * Properties:
+      + name: String
+      + isConcreteDevice: Bool
+      + operatingSystemVersion: String
+      + operatingSystemVersionWithBuildNumber: String
+      + nativeArchitecture: String
+      + modelName: String
+      + modelCode: String
+      + modelUTI: String
+      + identifier: String
+      + isWireless: Bool
+      + cpuKind: String
+      + cpuCount: Int?
+      + cpuSpeedInMHz: Int?
+      + busSpeedInMHz: Int?
+      + ramSizeInMegabytes: Int?
+      + physicalCPUCoresPerPackage: Int?
+      + logicalCPUCoresPerPackage: Int?
+      + platformRecord: ActionPlatformRecord
+  - ActionPlatformRecord
+    * Kind: object
+    * Properties:
+      + identifier: String
+      + userDescription: String
+  - ActionRecord
+    * Kind: object
+    * Properties:
+      + schemeCommandName: String
+      + schemeTaskName: String
+      + title: String?
+      + startedTime: Date
+      + endedTime: Date
+      + runDestination: ActionRunDestinationRecord
+      + buildResult: ActionResult
+      + actionResult: ActionResult
+  - ActionResult
+    * Kind: object
+    * Properties:
+      + resultName: String
+      + status: String
+      + metrics: ResultMetrics
+      + issues: ResultIssueSummaries
+      + coverage: CodeCoverageInfo
+      + timelineRef: Reference?
+      + logRef: Reference?
+      + testsRef: Reference?
+      + diagnosticsRef: Reference?
+  - ActionRunDestinationRecord
+    * Kind: object
+    * Properties:
+      + displayName: String
+      + targetArchitecture: String
+      + targetDeviceRecord: ActionDeviceRecord
+      + localComputerRecord: ActionDeviceRecord
+      + targetSDKRecord: ActionSDKRecord
+  - ActionSDKRecord
+    * Kind: object
+    * Properties:
+      + name: String
+      + identifier: String
+      + operatingSystemVersion: String
+      + isInternal: Bool
+  - ActionTestActivitySummary
+    * Kind: object
+    * Properties:
+      + title: String
+      + activityType: String
+      + uuid: String
+      + start: Date?
+      + finish: Date?
+      + attachments: [ActionTestAttachment]
+      + subactivities: [ActionTestActivitySummary]
+      + failureSummaryIDs: [String]
+  - ActionTestAttachment
+    * Kind: object
+    * Properties:
+      + uniformTypeIdentifier: String
+      + name: String?
+      + timestamp: Date?
+      + userInfo: SortedKeyValueArray?
+      + lifetime: String
+      + inActivityIdentifier: Int
+      + filename: String?
+      + payloadRef: Reference?
+      + payloadSize: Int
+  - ActionTestFailureSummary
+    * Kind: object
+    * Properties:
+      + message: String?
+      + fileName: String
+      + lineNumber: Int
+      + isPerformanceFailure: Bool
+      + uuid: String
+      + issueType: String?
+      + detailedDescription: String?
+      + attachments: [ActionTestAttachment]
+      + associatedError: TestAssociatedError?
+      + sourceCodeContext: SourceCodeContext?
+      + timestamp: Date?
+      + isTopLevelFailure: Bool
+  - ActionTestMetadata
+    * Supertype: ActionTestSummaryIdentifiableObject
+    * Kind: object
+    * Properties:
+      + testStatus: String
+      + duration: Double?
+      + summaryRef: Reference?
+      + performanceMetricsCount: Int
+      + failureSummariesCount: Int
+      + activitySummariesCount: Int
+  - ActionTestNoticeSummary
+    * Kind: object
+    * Properties:
+      + message: String?
+      + fileName: String
+      + lineNumber: Int
+  - ActionTestPerformanceMetricSummary
+    * Kind: object
+    * Properties:
+      + displayName: String
+      + unitOfMeasurement: String
+      + measurements: [Double]
+      + identifier: String?
+      + baselineName: String?
+      + baselineAverage: Double?
+      + maxPercentRegression: Double?
+      + maxPercentRelativeStandardDeviation: Double?
+      + maxRegression: Double?
+      + maxStandardDeviation: Double?
+  - ActionTestPlanRunSummaries
+    * Kind: object
+    * Properties:
+      + summaries: [ActionTestPlanRunSummary]
+  - ActionTestPlanRunSummary
+    * Supertype: ActionAbstractTestSummary
+    * Kind: object
+    * Properties:
+      + testableSummaries: [ActionTestableSummary]
+  - ActionTestSummary
+    * Supertype: ActionTestSummaryIdentifiableObject
+    * Kind: object
+    * Properties:
+      + testStatus: String
+      + duration: Double
+      + performanceMetrics: [ActionTestPerformanceMetricSummary]
+      + failureSummaries: [ActionTestFailureSummary]
+      + skipNoticeSummary: ActionTestNoticeSummary?
+      + activitySummaries: [ActionTestActivitySummary]
+  - ActionTestSummaryGroup
+    * Supertype: ActionTestSummaryIdentifiableObject
+    * Kind: object
+    * Properties:
+      + duration: Double
+      + subtests: [ActionTestSummaryIdentifiableObject]
+  - ActionTestSummaryIdentifiableObject
+    * Supertype: ActionAbstractTestSummary
+    * Kind: object
+    * Properties:
+      + identifier: String?
+  - ActionTestableSummary
+    * Supertype: ActionAbstractTestSummary
+    * Kind: object
+    * Properties:
+      + projectRelativePath: String?
+      + targetName: String?
+      + testKind: String?
+      + tests: [ActionTestSummaryIdentifiableObject]
+      + diagnosticsDirectoryName: String?
+      + failureSummaries: [ActionTestFailureSummary]
+      + testLanguage: String?
+      + testRegion: String?
+  - ActionsInvocationMetadata
+    * Kind: object
+    * Properties:
+      + creatingWorkspaceFilePath: String
+      + uniqueIdentifier: String
+      + schemeIdentifier: EntityIdentifier?
+  - ActionsInvocationRecord
+    * Kind: object
+    * Properties:
+      + metadataRef: Reference?
+      + metrics: ResultMetrics
+      + issues: ResultIssueSummaries
+      + actions: [ActionRecord]
+      + archive: ArchiveInfo?
+  - ActivityLogAnalyzerControlFlowStep
+    * Supertype: ActivityLogAnalyzerStep
+    * Kind: object
+    * Properties:
+      + title: String
+      + startLocation: DocumentLocation?
+      + endLocation: DocumentLocation?
+      + edges: [ActivityLogAnalyzerControlFlowStepEdge]
+  - ActivityLogAnalyzerControlFlowStepEdge
+    * Kind: object
+    * Properties:
+      + startLocation: DocumentLocation?
+      + endLocation: DocumentLocation?
+  - ActivityLogAnalyzerEventStep
+    * Supertype: ActivityLogAnalyzerStep
+    * Kind: object
+    * Properties:
+      + title: String
+      + location: DocumentLocation?
+      + description: String
+      + callDepth: Int
+  - ActivityLogAnalyzerResultMessage
+    * Supertype: ActivityLogMessage
+    * Kind: object
+    * Properties:
+      + steps: [ActivityLogAnalyzerStep]
+      + resultType: String?
+      + keyEventIndex: Int
+  - ActivityLogAnalyzerStep
+    * Kind: object
+    * Properties:
+      + parentIndex: Int
+  - ActivityLogAnalyzerWarningMessage
+    * Supertype: ActivityLogMessage
+    * Kind: object
+  - ActivityLogCommandInvocationSection
+    * Supertype: ActivityLogSection
+    * Kind: object
+    * Properties:
+      + commandDetails: String
+      + emittedOutput: String
+      + exitCode: Int?
+  - ActivityLogMajorSection
+    * Supertype: ActivityLogSection
+    * Kind: object
+    * Properties:
+      + subtitle: String
+  - ActivityLogMessage
+    * Kind: object
+    * Properties:
+      + type: String
+      + title: String
+      + shortTitle: String?
+      + category: String?
+      + location: DocumentLocation?
+      + annotations: [ActivityLogMessageAnnotation]
+  - ActivityLogMessageAnnotation
+    * Kind: object
+    * Properties:
+      + title: String
+      + location: DocumentLocation?
+  - ActivityLogSection
+    * Kind: object
+    * Properties:
+      + domainType: String
+      + title: String
+      + startTime: Date?
+      + duration: Double
+      + result: String?
+      + location: DocumentLocation?
+      + subsections: [ActivityLogSection]
+      + messages: [ActivityLogMessage]
+  - ActivityLogTargetBuildSection
+    * Supertype: ActivityLogMajorSection
+    * Kind: object
+    * Properties:
+      + productType: String?
+  - ActivityLogUnitTestSection
+    * Supertype: ActivityLogSection
+    * Kind: object
+    * Properties:
+      + testName: String?
+      + suiteName: String?
+      + summary: String?
+      + emittedOutput: String?
+      + performanceTestOutput: String?
+      + testsPassedString: String?
+      + wasSkipped: Bool
+      + runnablePath: String?
+      + runnableUTI: String?
+  - ArchiveInfo
+    * Kind: object
+    * Properties:
+      + path: String?
+  - Array
+    * Kind: array
+  - Bool
+    * Kind: value
+  - CodeCoverageInfo
+    * Kind: object
+    * Properties:
+      + hasCoverageData: Bool
+      + reportRef: Reference?
+      + archiveRef: Reference?
+  - Date
+    * Kind: value
+  - DocumentLocation
+    * Kind: object
+    * Properties:
+      + url: String
+      + concreteTypeName: String
+  - Double
+    * Kind: value
+  - EntityIdentifier
+    * Kind: object
+    * Properties:
+      + entityName: String
+      + containerName: String
+      + entityType: String
+      + sharedState: String
+  - Int
+    * Kind: value
+  - IssueSummary
+    * Kind: object
+    * Properties:
+      + issueType: String
+      + message: String
+      + producingTarget: String?
+      + documentLocationInCreatingWorkspace: DocumentLocation?
+  - ObjectID
+    * Kind: object
+    * Properties:
+      + hash: String
+  - Reference
+    * Kind: object
+    * Properties:
+      + id: String
+      + targetType: TypeDefinition?
+  - ResultIssueSummaries
+    * Kind: object
+    * Properties:
+      + analyzerWarningSummaries: [IssueSummary]
+      + errorSummaries: [IssueSummary]
+      + testFailureSummaries: [TestFailureIssueSummary]
+      + warningSummaries: [IssueSummary]
+  - ResultMetrics
+    * Kind: object
+    * Properties:
+      + analyzerWarningCount: Int
+      + errorCount: Int
+      + testsCount: Int
+      + testsFailedCount: Int
+      + testsSkippedCount: Int
+      + warningCount: Int
+  - SortedKeyValueArray
+    * Kind: object
+    * Properties:
+      + storage: [SortedKeyValueArrayPair]
+  - SortedKeyValueArrayPair
+    * Kind: object
+    * Properties:
+      + key: String
+      + value: SchemaSerializable
+  - SourceCodeContext
+    * Kind: object
+    * Properties:
+      + location: SourceCodeLocation?
+      + callStack: [SourceCodeFrame]
+  - SourceCodeFrame
+    * Kind: object
+    * Properties:
+      + addressString: String?
+      + symbolInfo: SourceCodeSymbolInfo?
+  - SourceCodeLocation
+    * Kind: object
+    * Properties:
+      + filePath: String?
+      + lineNumber: Int?
+  - SourceCodeSymbolInfo
+    * Kind: object
+    * Properties:
+      + imageName: String?
+      + symbolName: String?
+      + location: SourceCodeLocation?
+  - String
+    * Kind: value
+  - TestAssociatedError
+    * Kind: object
+    * Properties:
+      + domain: String?
+      + code: Int?
+      + userInfo: SortedKeyValueArray?
+  - TestFailureIssueSummary
+    * Supertype: IssueSummary
+    * Kind: object
+    * Properties:
+      + testCaseName: String
+  - TypeDefinition
+    * Kind: object
+    * Properties:
+      + name: String
+      + supertype: TypeDefinition?

--- a/Sources/XCParseCore/ActionTestActivitySummary.swift
+++ b/Sources/XCParseCore/ActionTestActivitySummary.swift
@@ -25,6 +25,9 @@ open class ActionTestActivitySummary : Codable {
     public let attachments: [ActionTestAttachment]
     public let subactivities: [ActionTestActivitySummary]
 
+    // xcresult 3.26 and above
+    public let failureSummaryIDs: [String]
+
     enum ActionTestActivitySummaryCodingKeys: String, CodingKey {
         case title
         case activityType
@@ -33,6 +36,7 @@ open class ActionTestActivitySummary : Codable {
         case finish
         case attachments
         case subactivities
+        case failureSummaryIDs
     }
 
      required public init(from decoder: Decoder) throws {
@@ -45,5 +49,6 @@ open class ActionTestActivitySummary : Codable {
 
         attachments = try container.decodeXCResultArray(forKey: .attachments)
         subactivities = try container.decodeXCResultArray(forKey: .subactivities)
+        failureSummaryIDs = try container.decodeXCResultArray(forKey: .failureSummaryIDs)
     }
 }

--- a/Sources/XCParseCore/ActionTestAttachment.swift
+++ b/Sources/XCParseCore/ActionTestAttachment.swift
@@ -17,7 +17,7 @@ open class ActionTestAttachment : Codable {
     public let uniformTypeIdentifier: String // Note: You'll want to use CoreServices' UTType functions with this
     public let name: String?
     public let timestamp: Date?
-//    public let userInfo: SortedKeyValueArray?
+    public let userInfo: SortedKeyValueArray?
     public let lifetime: String
     public let inActivityIdentifier: Int
     public let filename: String?
@@ -28,7 +28,7 @@ open class ActionTestAttachment : Codable {
         case uniformTypeIdentifier
         case name
         case timestamp
-//        case userInfo
+        case userInfo
         case lifetime
         case inActivityIdentifier
         case filename
@@ -41,7 +41,7 @@ open class ActionTestAttachment : Codable {
         uniformTypeIdentifier = try container.decodeXCResultType(forKey: .uniformTypeIdentifier)
         name = try container.decodeXCResultTypeIfPresent(forKey: .name)
         timestamp = try container.decodeXCResultTypeIfPresent(forKey: .timestamp)
-//        userInfo = try container.decodeXCResultObjectIfPresent(forKey: .userInfo)
+        userInfo = try container.decodeXCResultObjectIfPresent(forKey: .userInfo)
         lifetime = try container.decodeXCResultType(forKey: .lifetime)
         inActivityIdentifier = try container.decodeXCResultType(forKey: .inActivityIdentifier)
         filename = try container.decodeXCResultTypeIfPresent(forKey: .filename)

--- a/Sources/XCParseCore/ActionTestFailureSummary.swift
+++ b/Sources/XCParseCore/ActionTestFailureSummary.swift
@@ -14,11 +14,30 @@ open class ActionTestFailureSummary : Codable {
     public let lineNumber: Int
     public let isPerformanceFailure: Bool
 
+    // xcresult 3.26 and above
+    public let uuid: String
+    public let issueType: String?
+    public let detailedDescription: String?
+    public let attachments: [ActionTestAttachment] // TODO: Alex - look into whether we need to parse from this for screenshots command
+    public let associatedError: TestAssociatedError?
+    public let sourceCodeContext: SourceCodeContext?
+    public let timestamp: Date?
+    public let isTopLevelFailure: Bool
+
     enum ActionTestFailureSummaryCodingKeys: String, CodingKey {
         case message
         case fileName
         case lineNumber
         case isPerformanceFailure
+        // xcresult 3.26 and above
+        case uuid
+        case issueType
+        case detailedDescription
+        case attachments
+        case associatedError
+        case sourceCodeContext
+        case timestamp
+        case isTopLevelFailure
     }
 
      required public init(from decoder: Decoder) throws {
@@ -27,5 +46,14 @@ open class ActionTestFailureSummary : Codable {
         fileName = try container.decodeXCResultType(forKey: .fileName)
         lineNumber = try container.decodeXCResultType(forKey: .lineNumber)
         isPerformanceFailure = try container.decodeXCResultType(forKey: .isPerformanceFailure)
+
+        uuid = try container.decodeXCResultType(forKey: .uuid)
+        issueType = try container.decodeXCResultTypeIfPresent(forKey: .issueType)
+        detailedDescription = try container.decodeXCResultTypeIfPresent(forKey: .detailedDescription)
+        attachments = try container.decodeXCResultArray(forKey: .attachments)
+        associatedError = try container.decodeXCResultObjectIfPresent(forKey: .associatedError)
+        sourceCodeContext = try container.decodeXCResultObjectIfPresent(forKey: .sourceCodeContext)
+        timestamp = try container.decodeXCResultTypeIfPresent(forKey: .timestamp)
+        isTopLevelFailure = try container.decodeXCResultType(forKey: .isTopLevelFailure)
     }
 }

--- a/Sources/XCParseCore/SortedKeyValueArray.swift
+++ b/Sources/XCParseCore/SortedKeyValueArray.swift
@@ -1,0 +1,21 @@
+//
+//  SortedKeyValueArray.swift
+//  
+//
+//  Created by Alexander Botkin on 10/4/20.
+//
+
+import Foundation
+
+open class SortedKeyValueArray : Codable {
+    public let storage: [SortedKeyValueArrayPair]
+
+    enum SortedKeyValueArrayCodingKeys: String, CodingKey {
+        case storage
+    }
+
+     required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: SortedKeyValueArrayCodingKeys.self)
+        storage = try container.decodeXCResultArray(forKey: .storage)
+    }
+}

--- a/Sources/XCParseCore/SortedKeyValueArrayPair.swift
+++ b/Sources/XCParseCore/SortedKeyValueArrayPair.swift
@@ -1,0 +1,25 @@
+//
+//  SortedKeyValueArrayPair.swift
+//  
+//
+//  Created by Alexander Botkin on 10/4/20.
+//
+
+import Foundation
+
+
+open class SortedKeyValueArrayPair : Codable {
+    public let key: String
+    public let value: XCResultValueType
+
+    enum SortedKeyValueArrayPairCodingKeys: String, CodingKey {
+        case key
+        case value
+    }
+
+     required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: SortedKeyValueArrayPairCodingKeys.self)
+        key = try container.decodeXCResultType(forKey: .key)
+        value = try container.decodeXCResultObject(forKey: .value)
+    }
+}

--- a/Sources/XCParseCore/SourceCode/SourceCodeContext.swift
+++ b/Sources/XCParseCore/SourceCode/SourceCodeContext.swift
@@ -1,0 +1,24 @@
+//
+//  SourceCodeContext.swift
+//  
+//
+//  Created by Alexander Botkin on 10/4/20.
+//
+
+import Foundation
+
+open class SourceCodeContext : Codable {
+    public let location: SourceCodeLocation?
+    public let callStack: [SourceCodeFrame]
+
+    enum SourceCodeContextCodingKeys: String, CodingKey {
+        case location
+        case callStack
+    }
+
+     required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: SourceCodeContextCodingKeys.self)
+        location = try container.decodeXCResultObjectIfPresent(forKey: .location)
+        callStack = try container.decodeXCResultArray(forKey: .callStack)
+    }
+}

--- a/Sources/XCParseCore/SourceCode/SourceCodeFrame.swift
+++ b/Sources/XCParseCore/SourceCode/SourceCodeFrame.swift
@@ -1,0 +1,24 @@
+//
+//  SourceCodeFrame.swift
+//  
+//
+//  Created by Alexander Botkin on 10/4/20.
+//
+
+import Foundation
+
+open class SourceCodeFrame : Codable {
+    public let addressString: String?
+    public let symbolInfo: SourceCodeSymbolInfo?
+
+    enum SourceCodeFrameCodingKeys: String, CodingKey {
+        case addressString
+        case symbolInfo
+    }
+
+     required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: SourceCodeFrameCodingKeys.self)
+        addressString = try container.decodeXCResultTypeIfPresent(forKey: .addressString)
+        symbolInfo = try container.decodeXCResultObjectIfPresent(forKey: .symbolInfo)
+    }
+}

--- a/Sources/XCParseCore/SourceCode/SourceCodeLocation.swift
+++ b/Sources/XCParseCore/SourceCode/SourceCodeLocation.swift
@@ -1,0 +1,24 @@
+//
+//  SourceCodeLocation.swift
+//  
+//
+//  Created by Alexander Botkin on 10/4/20.
+//
+
+import Foundation
+
+open class SourceCodeLocation : Codable {
+    public let filePath: String?
+    public let lineNumber: Int?
+
+    enum SourceCodeLocationCodingKeys: String, CodingKey {
+        case filePath
+        case lineNumber
+    }
+
+     required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: SourceCodeLocationCodingKeys.self)
+        filePath = try container.decodeXCResultTypeIfPresent(forKey: .filePath)
+        lineNumber = try container.decodeXCResultTypeIfPresent(forKey: .lineNumber)
+    }
+}

--- a/Sources/XCParseCore/SourceCode/SourceCodeSymbolInfo.swift
+++ b/Sources/XCParseCore/SourceCode/SourceCodeSymbolInfo.swift
@@ -1,0 +1,27 @@
+//
+//  SourceCodeSymbolInfo.swift
+//  
+//
+//  Created by Alexander Botkin on 10/4/20.
+//
+
+import Foundation
+
+open class SourceCodeSymbolInfo : Codable {
+    public let imageName: String?
+    public let symbolName: String?
+    public let location: SourceCodeLocation?
+
+    enum SourceCodeSymbolInfoCodingKeys: String, CodingKey {
+        case imageName
+        case symbolName
+        case location
+    }
+
+     required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: SourceCodeSymbolInfoCodingKeys.self)
+        imageName = try container.decodeXCResultTypeIfPresent(forKey: .imageName)
+        symbolName = try container.decodeXCResultTypeIfPresent(forKey: .symbolName)
+        location = try container.decodeXCResultObjectIfPresent(forKey: .location)
+    }
+}

--- a/Sources/XCParseCore/TestAssociatedError.swift
+++ b/Sources/XCParseCore/TestAssociatedError.swift
@@ -1,0 +1,27 @@
+//
+//  TestAssociatedError.swift
+//  
+//
+//  Created by Alexander Botkin on 10/4/20.
+//
+
+import Foundation
+
+open class TestAssociatedError : Codable {
+    public let domain: String?
+    public let code: Int?
+//    public let userInfo: SortedKeyValueArray?
+
+    enum TestAssociatedErrorCodingKeys: String, CodingKey {
+        case domain
+        case code
+//        case userInfo
+    }
+
+     required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: TestAssociatedErrorCodingKeys.self)
+        domain = try container.decodeXCResultTypeIfPresent(forKey: .domain)
+        code = try container.decodeXCResultTypeIfPresent(forKey: .code)
+//        userInfo = try container.decodeXCResultObjectIfPresent(forKey: .userInfo)
+    }
+}

--- a/Sources/XCParseCore/TestAssociatedError.swift
+++ b/Sources/XCParseCore/TestAssociatedError.swift
@@ -10,18 +10,18 @@ import Foundation
 open class TestAssociatedError : Codable {
     public let domain: String?
     public let code: Int?
-//    public let userInfo: SortedKeyValueArray?
+    public let userInfo: SortedKeyValueArray?
 
     enum TestAssociatedErrorCodingKeys: String, CodingKey {
         case domain
         case code
-//        case userInfo
+        case userInfo
     }
 
      required public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: TestAssociatedErrorCodingKeys.self)
         domain = try container.decodeXCResultTypeIfPresent(forKey: .domain)
         code = try container.decodeXCResultTypeIfPresent(forKey: .code)
-//        userInfo = try container.decodeXCResultObjectIfPresent(forKey: .userInfo)
+        userInfo = try container.decodeXCResultObjectIfPresent(forKey: .userInfo)
     }
 }

--- a/Sources/XCParseCore/XCPResultDecoding.swift
+++ b/Sources/XCParseCore/XCPResultDecoding.swift
@@ -29,7 +29,7 @@ class XCResultArrayValue<T: Codable> : Codable {
     }
 }
 
-class XCResultValueType : Codable {
+public class XCResultValueType : Codable {
     let type: XCResultType
     let value: String
     
@@ -261,9 +261,9 @@ enum XCResultTypeFamily: String, ClassFamily {
         case .ResultMetrics:
             return XCParseCore.ResultMetrics.self
         case .SortedKeyValueArray:
-            return AnyObject.self
+            return XCParseCore.SortedKeyValueArray.self
         case .SortedKeyValueArrayPair:
-            return AnyObject.self
+            return XCParseCore.SortedKeyValueArrayPair.self
         case .String:
             return XCParseCore.XCResultValueType.self
         case .TestFailureIssueSummary:

--- a/Sources/XCParseCore/XCPResultDecoding.swift
+++ b/Sources/XCParseCore/XCPResultDecoding.swift
@@ -190,7 +190,7 @@ enum XCResultTypeFamily: String, ClassFamily {
         case .ActionTestAttachment:
             return XCParseCore.ActionTestAttachment.self
         case .ActionTestFailureSummary:
-            return XCParseCore.ActionTestActivitySummary.self
+            return XCParseCore.ActionTestFailureSummary.self
         case .ActionTestMetadata:
             return XCParseCore.ActionTestMetadata.self
         case .ActionTestPerformanceMetricSummary:

--- a/Sources/XCParseCore/XCPResultDecoding.swift
+++ b/Sources/XCParseCore/XCPResultDecoding.swift
@@ -158,7 +158,12 @@ enum XCResultTypeFamily: String, ClassFamily {
     case ResultMetrics
     case SortedKeyValueArray
     case SortedKeyValueArrayPair
+    case SourceCodeContext
+    case SourceCodeFrame
+    case SourceCodeLocation
+    case SourceCodeSymbolInfo
     case String
+    case TestAssociatedError
     case TestFailureIssueSummary
     case TypeDefinition
     
@@ -264,8 +269,18 @@ enum XCResultTypeFamily: String, ClassFamily {
             return XCParseCore.SortedKeyValueArray.self
         case .SortedKeyValueArrayPair:
             return XCParseCore.SortedKeyValueArrayPair.self
+        case .SourceCodeContext:
+            return XCParseCore.SourceCodeContext.self
+        case .SourceCodeFrame:
+            return XCParseCore.SourceCodeFrame.self
+        case .SourceCodeLocation:
+            return XCParseCore.SourceCodeLocation.self
+        case .SourceCodeSymbolInfo:
+            return XCParseCore.SourceCodeSymbolInfo.self
         case .String:
             return XCParseCore.XCResultValueType.self
+        case .TestAssociatedError:
+            return XCParseCore.TestAssociatedError.self
         case .TestFailureIssueSummary:
             return XCParseCore.TestFailureIssueSummary.self
         case .TypeDefinition:


### PR DESCRIPTION
**Change Description:** This fixes #50 by adding in the xcresult 3.26 data structures. It also adds back in the userInfo parsing that we removed early on in xcparse creation. This should allow for folks to get info such as the display scale from screenshot attachments. I've made a separate folder for the formatDescriptions so that we can keep track what we've added & make it easier for devs to compare and update when new Xcodes come out.

**Test Plan/Testing Performed:** Ran the existing unit tests to confirm that parsing is not regressed on them. Need to still add some Xcode 12 xcresults to double-check the new parsing.