### PR TITLE
[BUG] Xcparse not installing with Xcode 13.0 Beta 4 (#62)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "llbuild",
-        "repositoryURL": "https://github.com/apple/swift-llbuild.git",
+        "package": "swift-tools-support-core",
+        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "f73b84bc1525998e5e267f9d830c1411487ac65e",
-          "version": "0.2.0"
-        }
-      },
-      {
-        "package": "SwiftPM",
-        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
-        "state": {
-          "branch": null,
-          "revision": "9abcc2260438177cecd7cf5185b144d13e74122b",
-          "version": "0.5.0"
+          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
+          "version": "0.2.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,17 +18,17 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.5.0")),
+        .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.3")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "xcparse",
-            dependencies: [ "XCParseCore", "SPMUtility" ]),
+            dependencies: [ "XCParseCore", "SwiftToolsSupport" ]),
         .target(
             name: "XCParseCore",
-            dependencies: [ "SPMUtility" ]),
+            dependencies: [ "SwiftToolsSupport" ]),
         .testTarget(
             name: "xcparseTests",
             dependencies: ["xcparse"]),

--- a/Sources/XCParseCore/Console.swift
+++ b/Sources/XCParseCore/Console.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2019 ChargePoint, Inc. All rights reserved.
 //
 
-import Basic
 import Foundation
+import TSCBasic
 
 public enum OutputType {
   case error
@@ -42,7 +42,7 @@ open class Console {
     @discardableResult public func shellCommand(_ command: [String]) -> String {
         self.writeMessage("Command: \(command.joined(separator: " "))\n", to: .verbose)
 
-        let process = Basic.Process(arguments: command)
+        let process = TSCBasic.Process(arguments: command)
         do {
             try process.launch()
             let result = try process.waitUntilExit()

--- a/Sources/XCParseCore/Version+XCPTooling.swift
+++ b/Sources/XCParseCore/Version+XCPTooling.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import SPMUtility
+import TSCUtility
 
 public extension Version {
     static func xcresulttoolCompatibleWithUnicodeExportPath() -> Version {

--- a/Sources/XCParseCore/XCResultToolCommand.swift
+++ b/Sources/XCParseCore/XCResultToolCommand.swift
@@ -6,14 +6,14 @@
 //  Copyright © 2019 ChargePoint, Inc. All rights reserved.
 //
 
-import Basic
 import Foundation
-import SPMUtility
+import TSCBasic
+import TSCUtility
 
 let xcresultToolArguments = ["xcrun", "xcresulttool"]
 
 open class XCResultToolCommand {
-    let process: Basic.Process
+    let process: TSCBasic.Process
 
     let xcresult: XCResult
     var console: Console {
@@ -22,12 +22,12 @@ open class XCResultToolCommand {
         }
     }
 
-    public init(withXCResult xcresult: XCResult, process: Basic.Process = Basic.Process(arguments: ["xcrun", "xcresulttool", "-h"])) {
+    public init(withXCResult xcresult: XCResult, process: TSCBasic.Process = TSCBasic.Process(arguments: ["xcrun", "xcresulttool", "-h"])) {
         self.xcresult = xcresult
         self.process = process
     }
     
-    @discardableResult public func run() -> Basic.ProcessResult? {
+    @discardableResult public func run() -> TSCBasic.ProcessResult? {
         do {
             self.console.writeMessage("Command: \(process.arguments.joined(separator: " "))\n", to: .verbose)
 
@@ -76,7 +76,7 @@ open class XCResultToolCommand {
                                             "--id", self.id,
                                             "--output-path", self.outputPath])
 
-            let process = Basic.Process(arguments: processArgs)
+            let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)
         }
 
@@ -97,7 +97,7 @@ open class XCResultToolCommand {
                                             "--id", self.id,
                                             "--output-path", self.outputPath])
 
-            let process = Basic.Process(arguments: processArgs)
+            let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)
         }
     }
@@ -128,7 +128,7 @@ open class XCResultToolCommand {
                 processArgs.append(contentsOf: ["--output-path", self.outputPath])
             }
 
-            let process = Basic.Process(arguments: processArgs)
+            let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)
         }
     }
@@ -151,7 +151,7 @@ open class XCResultToolCommand {
                 processArgs.append(contentsOf: ["--version", "\(version)"])
             }
 
-            let process = Basic.Process(arguments: processArgs)
+            let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)
         }
     }
@@ -163,7 +163,7 @@ open class XCResultToolCommand {
             processArgs.append(contentsOf: ["metadata", "get",
                                             "--path", xcresult.path])
 
-            let process = Basic.Process(arguments: processArgs)
+            let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)
         }
     }
@@ -175,7 +175,7 @@ open class XCResultToolCommand {
             processArgs.append(contentsOf: ["version"])
 
             let xcresult = XCResult(path: "")
-            let process = Basic.Process(arguments: processArgs)
+            let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)
         }
     }

--- a/Sources/xcparse/AttachmentsCommand.swift
+++ b/Sources/xcparse/AttachmentsCommand.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2019 ChargePoint, Inc. All rights reserved.
 //
 
-import Basic
 import Foundation
-import SPMUtility
+import TSCBasic
+import TSCUtility
 
 struct AttachmentsCommand: Command {
     let command = "attachments"
@@ -59,7 +59,7 @@ struct AttachmentsCommand: Command {
         }
         let xcresultPath = xcresultPathArgument.path
 
-        var outputPath: AbsolutePath
+        var outputPath: TSCBasic.AbsolutePath
         if let outputPathArgument = arguments.get(self.outputPath) {
             outputPath = outputPathArgument.path
         } else if let workingDirectory = localFileSystem.currentWorkingDirectory {

--- a/Sources/xcparse/CodeCoverageCommand.swift
+++ b/Sources/xcparse/CodeCoverageCommand.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2019 ChargePoint, Inc. All rights reserved.
 //
 
-import Basic
 import Foundation
-import SPMUtility
+import TSCBasic
+import TSCUtility
 
 struct CodeCoverageCommand: Command {
     let command = "codecov"
@@ -35,7 +35,7 @@ struct CodeCoverageCommand: Command {
         }
         let xcresultPath = xcresultPathArgument.path
 
-        var outputPath: AbsolutePath
+        var outputPath: TSCBasic.AbsolutePath
         if let outputPathArgument = arguments.get(self.outputPath) {
             outputPath = outputPathArgument.path
         } else if let workingDirectory = localFileSystem.currentWorkingDirectory {

--- a/Sources/xcparse/Command.swift
+++ b/Sources/xcparse/Command.swift
@@ -6,9 +6,8 @@
 //  Copyright © 2019 ChargePoint, Inc. All rights reserved.
 //
 
-import Basic
 import Foundation
-import SPMUtility
+import TSCUtility
 
 // This is cribbed form a great blog post on ArgumentParser
 // https://www.enekoalonso.com/articles/handling-commands-with-swift-package-manager

--- a/Sources/xcparse/CommandRegistry.swift
+++ b/Sources/xcparse/CommandRegistry.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2019 ChargePoint, Inc. All rights reserved.
 //
 
-import Basic
 import Foundation
-import SPMUtility
+import TSCBasic
+import TSCUtility
 
 // This is cribbed form a great blog post on ArgumentParser
 // https://www.enekoalonso.com/articles/handling-commands-with-swift-package-manager
@@ -113,7 +113,7 @@ struct CommandRegistry {
         // We've determined it isn't a legacy command, so use new parsing
         guard let subparser = arguments.subparser(parser),
             let command = commands.first(where: { $0.command == subparser }) else {
-            parser.printUsage(on: stdoutStream)
+            parser.printUsage(on: TSCBasic.stdoutStream)
             return
         }
         try command.run(with: arguments)

--- a/Sources/xcparse/LogsCommand.swift
+++ b/Sources/xcparse/LogsCommand.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2019 ChargePoint, Inc. All rights reserved.
 //
 
-import Basic
 import Foundation
-import SPMUtility
+import TSCBasic
+import TSCUtility
 
 struct LogsCommand: Command {
     let command = "logs"
@@ -35,7 +35,7 @@ struct LogsCommand: Command {
         }
         let xcresultPath = xcresultPathArgument.path
 
-        var outputPath: AbsolutePath
+        var outputPath: TSCBasic.AbsolutePath
         if let outputPathArgument = arguments.get(self.outputPath) {
             outputPath = outputPathArgument.path
         } else if let workingDirectory = localFileSystem.currentWorkingDirectory {

--- a/Sources/xcparse/ScreenshotsCommand.swift
+++ b/Sources/xcparse/ScreenshotsCommand.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2019 ChargePoint, Inc. All rights reserved.
 //
 
-import Basic
 import Foundation
-import SPMUtility
+import TSCBasic
+import TSCUtility
 
 struct ScreenshotsCommand: Command {
     let command = "screenshots"
@@ -61,7 +61,7 @@ struct ScreenshotsCommand: Command {
         }
         let xcresultPath = xcresultPathArgument.path
 
-        var outputPath: AbsolutePath
+        var outputPath: TSCBasic.AbsolutePath
         if let outputPathArgument = arguments.get(self.outputPath) {
             outputPath = outputPathArgument.path
         } else if let workingDirectory = localFileSystem.currentWorkingDirectory {

--- a/Sources/xcparse/VersionCommand.swift
+++ b/Sources/xcparse/VersionCommand.swift
@@ -6,9 +6,8 @@
 //  Copyright © 2019 ChargePoint, Inc. All rights reserved.
 //
 
-import Basic
 import Foundation
-import SPMUtility
+import TSCUtility
 import XCParseCore
 
 struct VersionCommand: Command {

--- a/Sources/xcparse/XCPParser.swift
+++ b/Sources/xcparse/XCPParser.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2019 ChargePoint, Inc. All rights reserved.
 //
 
-import Basic
 import Foundation
-import SPMUtility
+import TSCBasic
+import TSCUtility
 import XCParseCore
 
 let xcparseCurrentVersion = Version(2, 1, 0)
@@ -272,7 +272,7 @@ class XCPParser {
         }
 
         let header = (displayName != "") ? "Exporting \"\(displayName)\" Attachments" : "Exporting Attachments"
-        let progressBar = PercentProgressAnimation(stream: stdoutStream, header: header)
+        let progressBar = PercentProgressAnimation(stream: TSCBasic.stdoutStream, header: header)
         progressBar.update(step: 0, total: attachments.count, text: "")
 
         for (index, attachment) in attachments.enumerated() {


### PR DESCRIPTION
**Change Description:** These changes fix #62. Swift 5.5 adds async/await & the Swift Package Manager 0.5.0 had an unfortunately named "await" function. The compiler did not take kindly to this & a fix is required in the SPM code [as seen done here](https://github.com/apple/swift-package-manager/commit/d48c99ced71989b607eae211704a288fd9c7179a).

In addition, SPMUtility was transitioned to TSCUtility in a new repo of [Swift Tools Core Support](https://github.com/apple/swift-tools-support-core) in late 2019/early 2020. Information about how to transition could be found in this [PR American Express did](https://github.com/americanexpress/xcprojectlint/pull/32) & [this updated blog post](https://rderik.com/blog/command-line-argument-parsing-using-swift-package-manager-s/) by @rderik.

This PR modifies Basic uses to TSCBasic & SPMUtility to TSCUtility from the new repo and pegs us to the current version as of July 2021 that has the commit fixing the await to tsc_await. It should be noted, we still need to go back and clean up all the new warnings as some of our usage from SPM 0.5.0 are deprecated in TSCUtility's latest version, but the functionality appears to work & unit tests pass so that can be a further cleanup task for @rsukumar-cpi 

**Test Plan/Testing Performed:** Ran the build on Xcode 13 beta 4 & confirmed that I could successfully build with the changes. Ran the unit tests & saw success.
