### PR TITLE
Add support for xcresult v3.34 (#64)

### DIFF
--- a/FormatDescriptions/xcresult-3.34.txt
+++ b/FormatDescriptions/xcresult-3.34.txt
@@ -1,0 +1,420 @@
+Name: Xcode Result Types
+Version: 3.34
+Signature: GSHghHjCrb8=
+Types:
+  - ActionAbstractTestSummary
+    * Kind: object
+    * Properties:
+      + name: String?
+  - ActionDeviceRecord
+    * Kind: object
+    * Properties:
+      + name: String
+      + isConcreteDevice: Bool
+      + operatingSystemVersion: String
+      + operatingSystemVersionWithBuildNumber: String
+      + nativeArchitecture: String
+      + modelName: String
+      + modelCode: String
+      + modelUTI: String
+      + identifier: String
+      + isWireless: Bool
+      + cpuKind: String
+      + cpuCount: Int?
+      + cpuSpeedInMHz: Int?
+      + busSpeedInMHz: Int?
+      + ramSizeInMegabytes: Int?
+      + physicalCPUCoresPerPackage: Int?
+      + logicalCPUCoresPerPackage: Int?
+      + platformRecord: ActionPlatformRecord
+  - ActionPlatformRecord
+    * Kind: object
+    * Properties:
+      + identifier: String
+      + userDescription: String
+  - ActionRecord
+    * Kind: object
+    * Properties:
+      + schemeCommandName: String
+      + schemeTaskName: String
+      + title: String?
+      + startedTime: Date
+      + endedTime: Date
+      + runDestination: ActionRunDestinationRecord
+      + buildResult: ActionResult
+      + actionResult: ActionResult
+  - ActionResult
+    * Kind: object
+    * Properties:
+      + resultName: String
+      + status: String
+      + metrics: ResultMetrics
+      + issues: ResultIssueSummaries
+      + coverage: CodeCoverageInfo
+      + timelineRef: Reference?
+      + logRef: Reference?
+      + testsRef: Reference?
+      + diagnosticsRef: Reference?
+  - ActionRunDestinationRecord
+    * Kind: object
+    * Properties:
+      + displayName: String
+      + targetArchitecture: String
+      + targetDeviceRecord: ActionDeviceRecord
+      + localComputerRecord: ActionDeviceRecord
+      + targetSDKRecord: ActionSDKRecord
+  - ActionSDKRecord
+    * Kind: object
+    * Properties:
+      + name: String
+      + identifier: String
+      + operatingSystemVersion: String
+      + isInternal: Bool
+  - ActionTestActivitySummary
+    * Kind: object
+    * Properties:
+      + title: String
+      + activityType: String
+      + uuid: String
+      + start: Date?
+      + finish: Date?
+      + attachments: [ActionTestAttachment]
+      + subactivities: [ActionTestActivitySummary]
+      + failureSummaryIDs: [String]
+      + expectedFailureIDs: [String]
+  - ActionTestAttachment
+    * Kind: object
+    * Properties:
+      + uniformTypeIdentifier: String
+      + name: String?
+      + uuid: String?
+      + timestamp: Date?
+      + userInfo: SortedKeyValueArray?
+      + lifetime: String
+      + inActivityIdentifier: Int
+      + filename: String?
+      + payloadRef: Reference?
+      + payloadSize: Int
+  - ActionTestConfiguration
+    * Kind: object
+    * Properties:
+      + values: SortedKeyValueArray
+  - ActionTestExpectedFailure
+    * Kind: object
+    * Properties:
+      + uuid: String
+      + failureReason: String?
+      + failureSummary: ActionTestFailureSummary?
+      + isTopLevelFailure: Bool
+  - ActionTestFailureSummary
+    * Kind: object
+    * Properties:
+      + message: String?
+      + fileName: String
+      + lineNumber: Int
+      + isPerformanceFailure: Bool
+      + uuid: String
+      + issueType: String?
+      + detailedDescription: String?
+      + attachments: [ActionTestAttachment]
+      + associatedError: TestAssociatedError?
+      + sourceCodeContext: SourceCodeContext?
+      + timestamp: Date?
+      + isTopLevelFailure: Bool
+  - ActionTestMetadata
+    * Supertype: ActionTestSummaryIdentifiableObject
+    * Kind: object
+    * Properties:
+      + testStatus: String
+      + duration: Double?
+      + summaryRef: Reference?
+      + performanceMetricsCount: Int
+      + failureSummariesCount: Int
+      + activitySummariesCount: Int
+  - ActionTestNoticeSummary
+    * Kind: object
+    * Properties:
+      + message: String?
+      + fileName: String
+      + lineNumber: Int
+  - ActionTestPerformanceMetricSummary
+    * Kind: object
+    * Properties:
+      + displayName: String
+      + unitOfMeasurement: String
+      + measurements: [Double]
+      + identifier: String?
+      + baselineName: String?
+      + baselineAverage: Double?
+      + maxPercentRegression: Double?
+      + maxPercentRelativeStandardDeviation: Double?
+      + maxRegression: Double?
+      + maxStandardDeviation: Double?
+      + polarity: String?
+  - ActionTestPlanRunSummaries
+    * Kind: object
+    * Properties:
+      + summaries: [ActionTestPlanRunSummary]
+  - ActionTestPlanRunSummary
+    * Supertype: ActionAbstractTestSummary
+    * Kind: object
+    * Properties:
+      + testableSummaries: [ActionTestableSummary]
+  - ActionTestRepetitionPolicySummary
+    * Kind: object
+    * Properties:
+      + iteration: Int?
+      + totalIterations: Int?
+      + repetitionMode: String?
+  - ActionTestSummary
+    * Supertype: ActionTestSummaryIdentifiableObject
+    * Kind: object
+    * Properties:
+      + testStatus: String
+      + duration: Double
+      + performanceMetrics: [ActionTestPerformanceMetricSummary]
+      + failureSummaries: [ActionTestFailureSummary]
+      + expectedFailures: [ActionTestExpectedFailure]
+      + skipNoticeSummary: ActionTestNoticeSummary?
+      + activitySummaries: [ActionTestActivitySummary]
+      + repetitionPolicySummary: ActionTestRepetitionPolicySummary?
+      + configuration: ActionTestConfiguration?
+  - ActionTestSummaryGroup
+    * Supertype: ActionTestSummaryIdentifiableObject
+    * Kind: object
+    * Properties:
+      + duration: Double
+      + subtests: [ActionTestSummaryIdentifiableObject]
+  - ActionTestSummaryIdentifiableObject
+    * Supertype: ActionAbstractTestSummary
+    * Kind: object
+    * Properties:
+      + identifier: String?
+  - ActionTestableSummary
+    * Supertype: ActionAbstractTestSummary
+    * Kind: object
+    * Properties:
+      + projectRelativePath: String?
+      + targetName: String?
+      + testKind: String?
+      + tests: [ActionTestSummaryIdentifiableObject]
+      + diagnosticsDirectoryName: String?
+      + failureSummaries: [ActionTestFailureSummary]
+      + testLanguage: String?
+      + testRegion: String?
+  - ActionsInvocationMetadata
+    * Kind: object
+    * Properties:
+      + creatingWorkspaceFilePath: String
+      + uniqueIdentifier: String
+      + schemeIdentifier: EntityIdentifier?
+  - ActionsInvocationRecord
+    * Kind: object
+    * Properties:
+      + metadataRef: Reference?
+      + metrics: ResultMetrics
+      + issues: ResultIssueSummaries
+      + actions: [ActionRecord]
+      + archive: ArchiveInfo?
+  - ActivityLogAnalyzerControlFlowStep
+    * Supertype: ActivityLogAnalyzerStep
+    * Kind: object
+    * Properties:
+      + title: String
+      + startLocation: DocumentLocation?
+      + endLocation: DocumentLocation?
+      + edges: [ActivityLogAnalyzerControlFlowStepEdge]
+  - ActivityLogAnalyzerControlFlowStepEdge
+    * Kind: object
+    * Properties:
+      + startLocation: DocumentLocation?
+      + endLocation: DocumentLocation?
+  - ActivityLogAnalyzerEventStep
+    * Supertype: ActivityLogAnalyzerStep
+    * Kind: object
+    * Properties:
+      + title: String
+      + location: DocumentLocation?
+      + description: String
+      + callDepth: Int
+  - ActivityLogAnalyzerResultMessage
+    * Supertype: ActivityLogMessage
+    * Kind: object
+    * Properties:
+      + steps: [ActivityLogAnalyzerStep]
+      + resultType: String?
+      + keyEventIndex: Int
+  - ActivityLogAnalyzerStep
+    * Kind: object
+    * Properties:
+      + parentIndex: Int
+  - ActivityLogAnalyzerWarningMessage
+    * Supertype: ActivityLogMessage
+    * Kind: object
+  - ActivityLogCommandInvocationSection
+    * Supertype: ActivityLogSection
+    * Kind: object
+    * Properties:
+      + commandDetails: String
+      + emittedOutput: String
+      + exitCode: Int?
+  - ActivityLogMajorSection
+    * Supertype: ActivityLogSection
+    * Kind: object
+    * Properties:
+      + subtitle: String
+  - ActivityLogMessage
+    * Kind: object
+    * Properties:
+      + type: String
+      + title: String
+      + shortTitle: String?
+      + category: String?
+      + location: DocumentLocation?
+      + annotations: [ActivityLogMessageAnnotation]
+  - ActivityLogMessageAnnotation
+    * Kind: object
+    * Properties:
+      + title: String
+      + location: DocumentLocation?
+  - ActivityLogSection
+    * Kind: object
+    * Properties:
+      + domainType: String
+      + title: String
+      + startTime: Date?
+      + duration: Double
+      + result: String?
+      + location: DocumentLocation?
+      + subsections: [ActivityLogSection]
+      + messages: [ActivityLogMessage]
+  - ActivityLogTargetBuildSection
+    * Supertype: ActivityLogMajorSection
+    * Kind: object
+    * Properties:
+      + productType: String?
+  - ActivityLogUnitTestSection
+    * Supertype: ActivityLogSection
+    * Kind: object
+    * Properties:
+      + testName: String?
+      + suiteName: String?
+      + summary: String?
+      + emittedOutput: String?
+      + performanceTestOutput: String?
+      + testsPassedString: String?
+      + wasSkipped: Bool
+      + runnablePath: String?
+      + runnableUTI: String?
+  - ArchiveInfo
+    * Kind: object
+    * Properties:
+      + path: String?
+  - Array
+    * Kind: array
+  - Bool
+    * Kind: value
+  - CodeCoverageInfo
+    * Kind: object
+    * Properties:
+      + hasCoverageData: Bool
+      + reportRef: Reference?
+      + archiveRef: Reference?
+  - Date
+    * Kind: value
+  - DocumentLocation
+    * Kind: object
+    * Properties:
+      + url: String
+      + concreteTypeName: String
+  - Double
+    * Kind: value
+  - EntityIdentifier
+    * Kind: object
+    * Properties:
+      + entityName: String
+      + containerName: String
+      + entityType: String
+      + sharedState: String
+  - Int
+    * Kind: value
+  - IssueSummary
+    * Kind: object
+    * Properties:
+      + issueType: String
+      + message: String
+      + producingTarget: String?
+      + documentLocationInCreatingWorkspace: DocumentLocation?
+  - ObjectID
+    * Kind: object
+    * Properties:
+      + hash: String
+  - Reference
+    * Kind: object
+    * Properties:
+      + id: String
+      + targetType: TypeDefinition?
+  - ResultIssueSummaries
+    * Kind: object
+    * Properties:
+      + analyzerWarningSummaries: [IssueSummary]
+      + errorSummaries: [IssueSummary]
+      + testFailureSummaries: [TestFailureIssueSummary]
+      + warningSummaries: [IssueSummary]
+  - ResultMetrics
+    * Kind: object
+    * Properties:
+      + analyzerWarningCount: Int
+      + errorCount: Int
+      + testsCount: Int
+      + testsFailedCount: Int
+      + testsSkippedCount: Int
+      + warningCount: Int
+  - SortedKeyValueArray
+    * Kind: object
+    * Properties:
+      + storage: [SortedKeyValueArrayPair]
+  - SortedKeyValueArrayPair
+    * Kind: object
+    * Properties:
+      + key: String
+      + value: SchemaSerializable
+  - SourceCodeContext
+    * Kind: object
+    * Properties:
+      + location: SourceCodeLocation?
+      + callStack: [SourceCodeFrame]
+  - SourceCodeFrame
+    * Kind: object
+    * Properties:
+      + addressString: String?
+      + symbolInfo: SourceCodeSymbolInfo?
+  - SourceCodeLocation
+    * Kind: object
+    * Properties:
+      + filePath: String?
+      + lineNumber: Int?
+  - SourceCodeSymbolInfo
+    * Kind: object
+    * Properties:
+      + imageName: String?
+      + symbolName: String?
+      + location: SourceCodeLocation?
+  - String
+    * Kind: value
+  - TestAssociatedError
+    * Kind: object
+    * Properties:
+      + domain: String?
+      + code: Int?
+      + userInfo: SortedKeyValueArray?
+  - TestFailureIssueSummary
+    * Supertype: IssueSummary
+    * Kind: object
+    * Properties:
+      + testCaseName: String
+  - TypeDefinition
+    * Kind: object
+    * Properties:
+      + name: String
+      + supertype: TypeDefinition?

--- a/Sources/XCParseCore/ActionTestActivitySummary.swift
+++ b/Sources/XCParseCore/ActionTestActivitySummary.swift
@@ -28,6 +28,9 @@ open class ActionTestActivitySummary : Codable {
     // xcresult 3.26 and above
     public let failureSummaryIDs: [String]
 
+    // xcresult 3.34 and above
+    public let expectedFailureIDs: [String]
+
     enum ActionTestActivitySummaryCodingKeys: String, CodingKey {
         case title
         case activityType
@@ -37,6 +40,7 @@ open class ActionTestActivitySummary : Codable {
         case attachments
         case subactivities
         case failureSummaryIDs
+        case expectedFailureIDs
     }
 
      required public init(from decoder: Decoder) throws {
@@ -50,5 +54,6 @@ open class ActionTestActivitySummary : Codable {
         attachments = try container.decodeXCResultArray(forKey: .attachments)
         subactivities = try container.decodeXCResultArray(forKey: .subactivities)
         failureSummaryIDs = try container.decodeXCResultArray(forKey: .failureSummaryIDs)
+        expectedFailureIDs = try container.decodeXCResultArray(forKey: .expectedFailureIDs)
     }
 }

--- a/Sources/XCParseCore/ActionTestAttachment.swift
+++ b/Sources/XCParseCore/ActionTestAttachment.swift
@@ -24,9 +24,13 @@ open class ActionTestAttachment : Codable {
     public let payloadRef: Reference?
     public let payloadSize: Int
 
+    // xcresult 3.34 and above
+    public let uuid: String?
+
     enum ActionTestAttachmentCodingKeys: String, CodingKey {
         case uniformTypeIdentifier
         case name
+        case uuid
         case timestamp
         case userInfo
         case lifetime
@@ -40,6 +44,7 @@ open class ActionTestAttachment : Codable {
         let container = try decoder.container(keyedBy: ActionTestAttachmentCodingKeys.self)
         uniformTypeIdentifier = try container.decodeXCResultType(forKey: .uniformTypeIdentifier)
         name = try container.decodeXCResultTypeIfPresent(forKey: .name)
+        uuid = try container.decodeXCResultTypeIfPresent(forKey: .uuid)
         timestamp = try container.decodeXCResultTypeIfPresent(forKey: .timestamp)
         userInfo = try container.decodeXCResultObjectIfPresent(forKey: .userInfo)
         lifetime = try container.decodeXCResultType(forKey: .lifetime)

--- a/Sources/XCParseCore/ActionTestConfiguration.swift
+++ b/Sources/XCParseCore/ActionTestConfiguration.swift
@@ -1,0 +1,23 @@
+//
+//  ActionTestConfiguration.swift
+//  XCParseCore
+//
+//  Created by Alex Botkin on 8/16/21.
+//  Copyright © 2021 ChargePoint, Inc. All rights reserved.
+//
+
+import Foundation
+
+// xcresult 3.34 and above
+open class ActionTestConfiguration : Codable {
+    public let values: SortedKeyValueArray
+
+    enum ActionTestConfigurationCodingKeys: String, CodingKey {
+        case values
+    }
+
+     required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: ActionTestConfigurationCodingKeys.self)
+        values = try container.decodeXCResultObject(forKey: .values)
+    }
+}

--- a/Sources/XCParseCore/ActionTestExpectedFailure.swift
+++ b/Sources/XCParseCore/ActionTestExpectedFailure.swift
@@ -1,0 +1,33 @@
+//
+//  ActionTestExpectedFailure.swift
+//  XCParseCore
+//
+//  Created by Alex Botkin on 8/16/21.
+//  Copyright © 2021 ChargePoint, Inc. All rights reserved.
+//
+
+import Foundation
+
+// xcresult 3.34 and above
+open class ActionTestExpectedFailure : Codable {
+    public let uuid: String
+    public let failureReason: String?
+    public let failureSummary: ActionTestFailureSummary?
+    public let isTopLevelFailure: Bool
+
+    enum ActionTestExpectedFailureCodingKeys: String, CodingKey {
+        case uuid
+        case failureReason
+        case failureSummary
+        case isTopLevelFailure
+    }
+
+     required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: ActionTestExpectedFailureCodingKeys.self)
+
+        uuid = try container.decodeXCResultType(forKey: .uuid)
+        failureReason = try container.decodeXCResultTypeIfPresent(forKey: .failureReason)
+        failureSummary = try container.decodeXCResultObjectIfPresent(forKey: .failureSummary)
+        isTopLevelFailure = try container.decodeXCResultType(forKey: .isTopLevelFailure)
+    }
+}

--- a/Sources/XCParseCore/ActionTestNoticeSummary.swift
+++ b/Sources/XCParseCore/ActionTestNoticeSummary.swift
@@ -1,0 +1,29 @@
+//
+//  ActionTestNoticeSummary.swift
+//  XCParseCore
+//
+//  Created by Alex Botkin on 8/16/21.
+//  Copyright © 2021 ChargePoint, Inc. All rights reserved.
+//
+
+import Foundation
+
+open class ActionTestNoticeSummary : Codable {
+    public let message: String?
+    public let fileName: String
+    public let lineNumber: Int
+
+    enum ActionTestNoticeSummaryCodingKeys: String, CodingKey {
+        case message
+        case fileName
+        case lineNumber
+    }
+
+     required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: ActionTestNoticeSummaryCodingKeys.self)
+
+        message = try container.decodeXCResultTypeIfPresent(forKey: .message)
+        fileName = try container.decodeXCResultType(forKey: .fileName)
+        lineNumber = try container.decodeXCResultType(forKey: .lineNumber)
+    }
+}

--- a/Sources/XCParseCore/ActionTestPerformanceMetricSummary.swift
+++ b/Sources/XCParseCore/ActionTestPerformanceMetricSummary.swift
@@ -54,6 +54,9 @@ open class ActionTestPerformanceMetricSummary : Codable {
     public let maxRegression: Double?
     public let maxStandardDeviation: Double?
 
+    // xcresult 3.34 and above
+    public let polarity: String?
+
     // Derived
     public var metricType : ActionTestPerformanceMetric {
         let identifierString = identifier ?? "Identifier Missing"
@@ -71,6 +74,7 @@ open class ActionTestPerformanceMetricSummary : Codable {
         case maxPercentRelativeStandardDeviation
         case maxRegression
         case maxStandardDeviation
+        case polarity
     }
 
      required public init(from decoder: Decoder) throws {
@@ -87,5 +91,6 @@ open class ActionTestPerformanceMetricSummary : Codable {
         maxPercentRelativeStandardDeviation = try container.decodeXCResultTypeIfPresent(forKey: .maxPercentRelativeStandardDeviation)
         maxRegression = try container.decodeXCResultTypeIfPresent(forKey: .maxRegression)
         maxStandardDeviation = try container.decodeXCResultTypeIfPresent(forKey: .maxStandardDeviation)
+        polarity = try container.decodeXCResultTypeIfPresent(forKey: .polarity)
     }
 }

--- a/Sources/XCParseCore/ActionTestRepetitionPolicySummary.swift
+++ b/Sources/XCParseCore/ActionTestRepetitionPolicySummary.swift
@@ -1,0 +1,30 @@
+//
+//  ActionTestRepetitionPolicySummary.swift
+//  XCParseCore
+//
+//  Created by Alex Botkin on 8/16/21.
+//  Copyright © 2021 ChargePoint, Inc. All rights reserved.
+//
+
+import Foundation
+
+// xcresult 3.34 and above
+open class ActionTestRepetitionPolicySummary : Codable {
+    public let iteration: Int?
+    public let totalIterations: Int?
+    public let repetitionMode: String?
+
+    enum ActionTestRepetitionPolicySummaryCodingKeys: String, CodingKey {
+        case iteration
+        case totalIterations
+        case repetitionMode
+    }
+
+     required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: ActionTestRepetitionPolicySummaryCodingKeys.self)
+
+        iteration = try container.decodeXCResultTypeIfPresent(forKey: .iteration)
+        totalIterations = try container.decodeXCResultTypeIfPresent(forKey: .totalIterations)
+        repetitionMode = try container.decodeXCResultTypeIfPresent(forKey: .repetitionMode)
+    }
+}

--- a/Sources/XCParseCore/ActionTestSummary.swift
+++ b/Sources/XCParseCore/ActionTestSummary.swift
@@ -3,7 +3,7 @@
 //  XCParseCore
 //
 //  Created by Alex Botkin on 10/4/19.
-//  Copyright © 2019 ChargePoint, Inc. All rights reserved.
+//  Copyright © 2021 ChargePoint, Inc. All rights reserved.
 //
 
 import Foundation
@@ -18,26 +18,24 @@ open class ActionTestSummary : ActionTestSummaryIdentifiableObject {
     public let duration: Double
     public let performanceMetrics: [ActionTestPerformanceMetricSummary]
     public let failureSummaries: [ActionTestFailureSummary]
+    public let skipNoticeSummary: ActionTestNoticeSummary?
     public let activitySummaries: [ActionTestActivitySummary]
 
-    // Missing from earlier additions
-//    public let skipNoticeSummary: ActionTestNoticeSummary?
-
     // xcresult 3.34 and above
-//    public let expectedFailures: [ActionTestExpectedFailure]
-//    public let repetitionPolicySummary: ActionTestRepetitionPolicySummary?
-//    public let configuration: ActionTestConfiguration?
+    public let expectedFailures: [ActionTestExpectedFailure]
+    public let repetitionPolicySummary: ActionTestRepetitionPolicySummary?
+    public let configuration: ActionTestConfiguration?
 
     enum ActionTestSummaryCodingKeys: String, CodingKey {
         case testStatus
         case duration
         case performanceMetrics
         case failureSummaries
+        case skipNoticeSummary
         case activitySummaries
-//        case skipNoticeSummary
-//        case expectedFailures
-//        case repetitionPolicySummary
-//        case configuration
+        case expectedFailures
+        case repetitionPolicySummary
+        case configuration
     }
 
      required public init(from decoder: Decoder) throws {
@@ -47,13 +45,12 @@ open class ActionTestSummary : ActionTestSummaryIdentifiableObject {
 
         performanceMetrics = try container.decodeXCResultArray(forKey: .performanceMetrics)
         failureSummaries = try container.decodeXCResultArray(forKey: .failureSummaries)
+        skipNoticeSummary = try container.decodeXCResultObjectIfPresent(forKey: .skipNoticeSummary)
         activitySummaries = try container.decodeXCResultArray(forKey: .activitySummaries)
 
-//        skipNoticeSummary = try container.decodeXCResultObjectIfPresent(forKey: .skipNoticeSummary)
-//
-//        expectedFailures = try container.decodeXCResultArray(forKey: .expectedFailures)
-//        repetitionPolicySummary = try container.decodeXCResultObjectIfPresent(forKey: .repetitionPolicySummary)
-//        configuration = try container.decodeXCResultObjectIfPresent(forKey: .configuration)
+        expectedFailures = try container.decodeXCResultArray(forKey: .expectedFailures)
+        repetitionPolicySummary = try container.decodeXCResultObjectIfPresent(forKey: .repetitionPolicySummary)
+        configuration = try container.decodeXCResultObjectIfPresent(forKey: .configuration)
 
         try super.init(from: decoder)
     }

--- a/Sources/XCParseCore/ActionTestSummary.swift
+++ b/Sources/XCParseCore/ActionTestSummary.swift
@@ -20,12 +20,24 @@ open class ActionTestSummary : ActionTestSummaryIdentifiableObject {
     public let failureSummaries: [ActionTestFailureSummary]
     public let activitySummaries: [ActionTestActivitySummary]
 
+    // Missing from earlier additions
+//    public let skipNoticeSummary: ActionTestNoticeSummary?
+
+    // xcresult 3.34 and above
+//    public let expectedFailures: [ActionTestExpectedFailure]
+//    public let repetitionPolicySummary: ActionTestRepetitionPolicySummary?
+//    public let configuration: ActionTestConfiguration?
+
     enum ActionTestSummaryCodingKeys: String, CodingKey {
         case testStatus
         case duration
         case performanceMetrics
         case failureSummaries
         case activitySummaries
+//        case skipNoticeSummary
+//        case expectedFailures
+//        case repetitionPolicySummary
+//        case configuration
     }
 
      required public init(from decoder: Decoder) throws {
@@ -36,6 +48,12 @@ open class ActionTestSummary : ActionTestSummaryIdentifiableObject {
         performanceMetrics = try container.decodeXCResultArray(forKey: .performanceMetrics)
         failureSummaries = try container.decodeXCResultArray(forKey: .failureSummaries)
         activitySummaries = try container.decodeXCResultArray(forKey: .activitySummaries)
+
+//        skipNoticeSummary = try container.decodeXCResultObjectIfPresent(forKey: .skipNoticeSummary)
+//
+//        expectedFailures = try container.decodeXCResultArray(forKey: .expectedFailures)
+//        repetitionPolicySummary = try container.decodeXCResultObjectIfPresent(forKey: .repetitionPolicySummary)
+//        configuration = try container.decodeXCResultObjectIfPresent(forKey: .configuration)
 
         try super.init(from: decoder)
     }

--- a/Sources/XCParseCore/XCPResultDecoding.swift
+++ b/Sources/XCParseCore/XCPResultDecoding.swift
@@ -3,7 +3,7 @@
 //  xcparse
 //
 //  Created by Alex Botkin on 8/13/19.
-//  Copyright © 2019 ChargePoint, Inc. All rights reserved.
+//  Copyright © 2021 ChargePoint, Inc. All rights reserved.
 //
 
 import Foundation
@@ -118,11 +118,15 @@ enum XCResultTypeFamily: String, ClassFamily {
     case ActionSDKRecord
     case ActionTestActivitySummary
     case ActionTestAttachment
+    case ActionTestConfiguration
+    case ActionTestExpectedFailure
     case ActionTestFailureSummary
     case ActionTestMetadata
+    case ActionTestNoticeSummary
     case ActionTestPerformanceMetricSummary
     case ActionTestPlanRunSummaries
     case ActionTestPlanRunSummary
+    case ActionTestRepetitionPolicySummary
     case ActionTestSummary
     case ActionTestSummaryGroup
     case ActionTestSummaryIdentifiableObject
@@ -189,16 +193,24 @@ enum XCResultTypeFamily: String, ClassFamily {
             return XCParseCore.ActionTestActivitySummary.self
         case .ActionTestAttachment:
             return XCParseCore.ActionTestAttachment.self
+        case .ActionTestConfiguration:
+            return XCParseCore.ActionTestConfiguration.self
+        case .ActionTestExpectedFailure:
+            return XCParseCore.ActionTestExpectedFailure.self
         case .ActionTestFailureSummary:
             return XCParseCore.ActionTestFailureSummary.self
         case .ActionTestMetadata:
             return XCParseCore.ActionTestMetadata.self
+        case .ActionTestNoticeSummary:
+            return XCParseCore.ActionTestNoticeSummary.self
         case .ActionTestPerformanceMetricSummary:
             return XCParseCore.ActionTestPerformanceMetricSummary.self
         case .ActionTestPlanRunSummaries:
             return XCParseCore.ActionTestPlanRunSummaries.self
         case .ActionTestPlanRunSummary:
             return XCParseCore.ActionTestPlanRunSummary.self
+        case .ActionTestRepetitionPolicySummary:
+            return XCParseCore.ActionTestRepetitionPolicySummary.self
         case .ActionTestSummary:
             return XCParseCore.ActionTestSummary.self
         case .ActionTestSummaryGroup:


### PR DESCRIPTION
**Change Description:** Adds support for new properties and objects described in xcresulttool's v3.34 of the formatDescription.

**Test Plan/Testing Performed:** Need to add unit tests for the new objects. Was able to confirm that new UUID properties were parsing out properly with existing xcresult.