### PR TITLE
[IMA-11727] Modify Makefile to build universal xcparse binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ bindir = $(prefix)/bin
 libdir = $(prefix)/lib
 
 build:
-	swift build -c release --disable-sandbox
+	swift build -c release --disable-sandbox --arch arm64 --arch x86_64
 
 install: build
-	install ".build/release/xcparse" "$(bindir)"
+	install ".build/apple/Products/Release/xcparse" "$(bindir)"
 
 uninstall:
 	rm -rf "$(bindir)/xcparse"

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.3")),
+        .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.4")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
**Change Description:**
1. Modify Makefile to build for arm64 and x86_64 architectures.
2. Up the swift-tools-support-core version to the latest (0.2.4).

**Test Plan/Testing Performed:**
1. Built xcparse locally and confirmed that the binary is built for both architectures. Modified Bitrise workflows to conform to the new build directory structure. 
2. Created 'deploy' workflow on Bitrise to automate the release process including the universal binary in future release assets.