### PR TITLE
[IMA-12624] Up version of swift-tools-support-core to 0.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,21 @@
   "object": {
     "pins": [
       {
+        "package": "swift-system",
+        "repositoryURL": "https://github.com/apple/swift-system.git",
+        "state": {
+          "branch": null,
+          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
+          "version": "1.1.1"
+        }
+      },
+      {
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "f9bbd6b80d67408021576adf6247e17c2e957d92",
-          "version": "0.2.4"
+          "revision": "0b77e67c484e532444ceeab60119b8536f8cd648",
+          "version": "0.3.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.4")),
+        .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.3.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
**Change Description:**
1. Up version of swift-tools-support-core to 0.3.0.

**Test Plan/Testing Performed:**
1. Tested `make install` locally with both Xcode 13 and Xcode 14 stack.