### PR TITLE
Use attachment timestamp as modification date of exported attachment file

### DIFF
--- a/Sources/XCParseCore/XCResultToolCommand.swift
+++ b/Sources/XCParseCore/XCResultToolCommand.swift
@@ -63,11 +63,13 @@ open class XCResultToolCommand {
         var id: String = ""
         var outputPath: String = ""
         var type: ExportType = ExportType.file
+        private let timestamp: Date?
         
         public init(withXCResult xcresult: XCResult, id: String, outputPath: String, type: ExportType) {
             self.id = id
             self.outputPath = outputPath
             self.type = type
+            self.timestamp = nil
 
             var processArgs = xcresultToolArguments
             processArgs.append(contentsOf: ["export",
@@ -89,6 +91,7 @@ open class XCResultToolCommand {
                 let attachmentOutputPath = URL.init(fileURLWithPath: outputPath).appendingPathComponent(filename)
                 self.outputPath = attachmentOutputPath.path
             }
+            self.timestamp = attachment.timestamp
 
             var processArgs = xcresultToolArguments
             processArgs.append(contentsOf: ["export",
@@ -99,6 +102,14 @@ open class XCResultToolCommand {
 
             let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)
+        }
+
+        public override func run() -> ProcessResult? {
+            let superResult = super.run()
+            if superResult == nil { return nil }
+            guard let timestamp else { return superResult }
+            try? FileManager.default.setAttributes([.modificationDate: timestamp as Any], ofItemAtPath: outputPath)
+            return superResult
         }
     }
 


### PR DESCRIPTION
**Change Description**
Hi!

First of all, thank you for building this library! It's been very useful for us in making screenshots available on Bitrise for our failing UI tests.

However, as you are aware, a lot of people (including us) would find it convenient to be able to view the exported screenshots in the order they were taken in the tests. I saw that there have been some discussions about this previously (#38, #42), but as far as I could tell nothing concrete has come off it, so I decided to take a stab at it!

Instead of solving the problem by changing the exported filename—which requires a lot of considerations as seen in #38—I opted to simply set the modification date of the exported file. Prior to this change the modification date would be the date of when `xcparse` wrote the exported file to disk. Setting the modification date to the attachment's timestamp means that the screenshots can be viewed in the order they were taken simply by sorting by the modification date. This is supported out-of-the box in Finder and using the `-t` flag for `ls` in the terminal.

**Test Plan/Testing Performed**
It feels like quite a safe change, so I've only performed a little bit of manual testing on an `xcresult` bundle. However I'd be happy to get some help with writing unit tests and/or doing some more manual testing on other result bundles!

