### PR TITLE
Added an option to divide by device identifier

### DIFF
--- a/Sources/xcparse/AttachmentsCommand.swift
+++ b/Sources/xcparse/AttachmentsCommand.swift
@@ -19,6 +19,7 @@ struct AttachmentsCommand: Command {
     var outputPath: PositionalArgument<PathArgument>
     var verbose: OptionArgument<Bool>
 
+    var divideByIdentifier: OptionArgument<Bool>
     var divideByModel: OptionArgument<Bool>
     var divideByOS: OptionArgument<Bool>
     var divideByTestRun: OptionArgument<Bool>
@@ -38,6 +39,7 @@ struct AttachmentsCommand: Command {
                                    optional: true, usage: "Folder to export results to", completion: .filename)
         verbose = subparser.add(option: "--verbose", shortName: "-v", kind: Bool.self, usage: "Enable verbose logging")
 
+        divideByIdentifier = subparser.add(option: "--identifier", shortName: nil, kind: Bool.self, usage: "Divide attachments by device identifier")
         divideByModel = subparser.add(option: "--model", shortName: nil, kind: Bool.self, usage: "Divide attachments by model")
         divideByOS = subparser.add(option: "--os", shortName: nil, kind: Bool.self, usage: "Divide attachments by OS")
         divideByTestRun = subparser.add(option: "--test-run", shortName: nil, kind: Bool.self, usage: "Deprecated. Use --test-plan-config")
@@ -80,6 +82,7 @@ struct AttachmentsCommand: Command {
 
         // Let's set up our export options
         var options = AttachmentExportOptions(addTestScreenshotsDirectory: false,
+                                              divideByIdentifier: arguments.get(self.divideByIdentifier) ?? false,
                                               divideByTargetModel: arguments.get(self.divideByModel) ?? false,
                                               divideByTargetOS: arguments.get(self.divideByOS) ?? false,
                                               divideByTestPlanConfig: arguments.get(self.divideByTestPlanConfig) ?? (arguments.get(self.divideByTestRun) ?? false),

--- a/Sources/xcparse/CommandRegistry.swift
+++ b/Sources/xcparse/CommandRegistry.swift
@@ -65,6 +65,7 @@ struct CommandRegistry {
             let xcresulttoolCompatability = xcpParser.checkXCResultToolCompatability(destination: destination)
 
             let options = AttachmentExportOptions(addTestScreenshotsDirectory: true,
+                                                  divideByIdentifier: false,
                                                   divideByTargetModel: false,
                                                   divideByTargetOS: false,
                                                   divideByTestPlanConfig: false,

--- a/Sources/xcparse/ScreenshotsCommand.swift
+++ b/Sources/xcparse/ScreenshotsCommand.swift
@@ -20,6 +20,7 @@ struct ScreenshotsCommand: Command {
     var verbose: OptionArgument<Bool>
 
     var addTestScreenshotDirectory: OptionArgument<Bool>
+    var divideByIdentifier: OptionArgument<Bool>
     var divideByModel: OptionArgument<Bool>
     var divideByOS: OptionArgument<Bool>
     var divideByTestRun: OptionArgument<Bool>
@@ -40,6 +41,7 @@ struct ScreenshotsCommand: Command {
         verbose = subparser.add(option: "--verbose", shortName: "-v", kind: Bool.self, usage: "Enable verbose logging")
 
         addTestScreenshotDirectory = subparser.add(option: "--legacy", shortName: nil, kind: Bool.self, usage: "Create \"testScreenshots\" directory in outputDirectory & put screenshots in there")
+        divideByIdentifier = subparser.add(option: "--identifier", shortName: nil, kind: Bool.self, usage: "Divide attachments by device identifier")
         divideByModel = subparser.add(option: "--model", shortName: nil, kind: Bool.self, usage: "Divide screenshots by model")
         divideByOS = subparser.add(option: "--os", shortName: nil, kind: Bool.self, usage: "Divide screenshots by OS")
         divideByTestRun = subparser.add(option: "--test-run", shortName: nil, kind: Bool.self, usage: "Deprecated. Use --test-plan-config")
@@ -82,6 +84,7 @@ struct ScreenshotsCommand: Command {
 
         // Let's set up our export options
         var options = AttachmentExportOptions(addTestScreenshotsDirectory: arguments.get(self.addTestScreenshotDirectory) ?? false,
+                                              divideByIdentifier: arguments.get(self.divideByIdentifier) ?? false,
                                               divideByTargetModel: arguments.get(self.divideByModel) ?? false,
                                               divideByTargetOS: arguments.get(self.divideByOS) ?? false,
                                               divideByTestPlanConfig: arguments.get(self.divideByTestPlanConfig) ?? (arguments.get(self.divideByTestRun) ?? false),

--- a/Sources/xcparse/XCPParser.swift
+++ b/Sources/xcparse/XCPParser.swift
@@ -21,6 +21,7 @@ struct XCResultToolCompatability {
 
 struct AttachmentExportOptions {
     var addTestScreenshotsDirectory: Bool = false
+    var divideByIdentifier: Bool = false
     var divideByTargetModel: Bool = false
     var divideByTargetOS: Bool = false
     var divideByTestPlanConfig: Bool = false
@@ -58,7 +59,9 @@ struct AttachmentExportOptions {
             modelName = "iPhone XR"
         }
 
-        if self.divideByTargetModel == true, self.divideByTargetOS == true {
+        if self.divideByIdentifier {
+            targetDeviceFolderName = deviceRecord.identifier
+        } else if self.divideByTargetModel == true, self.divideByTargetOS == true {
             targetDeviceFolderName = modelName + " (\(deviceRecord.operatingSystemVersion))"
         } else if self.divideByTargetModel {
             targetDeviceFolderName = modelName

--- a/Tests/xcparseTests/xcparseTests.swift
+++ b/Tests/xcparseTests/xcparseTests.swift
@@ -35,6 +35,7 @@ final class xcparseTests: XCTestCase {
     static var allTests = [
         ("testScreenshots", testScreenshots),
         ("testDivideByTestPlanConfig",testDivideByTestPlanConfig),
+        ("testDivideByIdentifier",testDivideByIdentifier),
         ("testDivideByOS",testDivideByOS),
         ("testDivideByModel",testDivideByModel),
         ("testDivideByLanguage",testDivideByLanguage),
@@ -254,6 +255,27 @@ final class xcparseTests: XCTestCase {
         XCTAssertTrue(fileUrls.filter{$0.path.contains("MyAutomation_darkMapView")}.count == 1)
         XCTAssertTrue(fileUrls.filter{$0.path.contains("MyAutomation_todayWidget")}.count == 1)
 
+    }
+
+    func testDivideByIdentifier() throws {
+        // Some of the APIs that we use below are available in macOS 10.13 and above.
+        guard #available(macOS 10.13, *) else {
+            return
+        }
+
+        let file = try Resource(name: "testSuccess", type: "xcresult")
+        xcparseProcess.arguments = ["screenshots","--identifier",file.url.path,temporaryOutputDirectoryURL.path]
+
+        try runAndWaitForXCParseProcess()
+
+        // check for the files. The device identifier in xcresult is BFB8C9E3-0E55-4E20-B332-091631DF4F90 for simulator
+        // so we append "BFB8C9E3-0E55-4E20-B332-091631DF4F90" to temporary directory
+
+        let fileUrls = FileManager.default.listFiles(path: temporaryOutputDirectoryURL.appendingPathComponent("BFB8C9E3-0E55-4E20-B332-091631DF4F90").path)
+
+        XCTAssertTrue(fileUrls.count ==  6)
+        XCTAssertTrue(fileUrls.filter{$0.path.contains("MyAutomation_darkMapView")}.count == 3)
+        XCTAssertTrue(fileUrls.filter{$0.path.contains("MyAutomation_todayWidget")}.count == 3)
     }
 
     func testDivideByOS() throws {


### PR DESCRIPTION
**Change Description:**

Added an option to divide attachments by target identifier. Using `--identifier` will export the attachments into folders named after the device identifier. This option takes precedence over `--model` and `--os`, hence these options will be ignored if `--identifier` is passed. This can be useful if tests are run on two devices with same model and os.


**Test Plan/Testing Performed:**

Tests have been updated to ensure that this new command works correctly.
