### PR TITLE
Add `--legacy` flag for Xcode 16 compatibility

### DIFF
--- a/Sources/XCParseCore/Version+XCPTooling.swift
+++ b/Sources/XCParseCore/Version+XCPTooling.swift
@@ -13,6 +13,10 @@ public extension Version {
         return Version(15500, 0, 0)
     }
 
+    static func xcresulttoolWithDeprecatedAPIs() -> Version {
+        return Version(23028, 0, 0)
+    }
+
     static func xcresulttool() -> Version? {
         guard let xcresulttoolVersionResult = XCResultToolCommand.Version().run() else {
             return nil

--- a/Sources/XCParseCore/XCResultToolCommand.swift
+++ b/Sources/XCParseCore/XCResultToolCommand.swift
@@ -153,6 +153,7 @@ open class XCResultToolCommand {
             if let version = self.version {
                 processArgs.append(contentsOf: ["--version", "\(version)"])
             }
+            processArgs.append("--legacy")
 
             let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)

--- a/Sources/XCParseCore/XCResultToolCommand.swift
+++ b/Sources/XCParseCore/XCResultToolCommand.swift
@@ -74,7 +74,8 @@ open class XCResultToolCommand {
                                             "--type", self.type.rawValue,
                                             "--path", xcresult.path,
                                             "--id", self.id,
-                                            "--output-path", self.outputPath])
+                                            "--output-path", self.outputPath,
+                                            "--legacy"])
 
             let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)
@@ -95,7 +96,8 @@ open class XCResultToolCommand {
                                             "--type", self.type.rawValue,
                                             "--path", xcresult.path,
                                             "--id", self.id,
-                                            "--output-path", self.outputPath])
+                                            "--output-path", self.outputPath,
+                                            "--legacy"])
 
             let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)

--- a/Sources/XCParseCore/XCResultToolCommand.swift
+++ b/Sources/XCParseCore/XCResultToolCommand.swift
@@ -74,8 +74,8 @@ open class XCResultToolCommand {
                                             "--type", self.type.rawValue,
                                             "--path", xcresult.path,
                                             "--id", self.id,
-                                            "--output-path", self.outputPath,
-                                            "--legacy"])
+                                            "--output-path", self.outputPath])
+            processArgs.addLegacyFlagIfNeeded()
 
             let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)
@@ -96,8 +96,9 @@ open class XCResultToolCommand {
                                             "--type", self.type.rawValue,
                                             "--path", xcresult.path,
                                             "--id", self.id,
-                                            "--output-path", self.outputPath,
-                                            "--legacy"])
+                                            "--output-path", self.outputPath])
+
+            processArgs.addLegacyFlagIfNeeded()
 
             let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)
@@ -129,7 +130,7 @@ open class XCResultToolCommand {
             if self.outputPath != "" {
                 processArgs.append(contentsOf: ["--output-path", self.outputPath])
             }
-            processArgs.append("--legacy")
+            processArgs.addLegacyFlagIfNeeded()
 
             let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)
@@ -153,7 +154,7 @@ open class XCResultToolCommand {
             if let version = self.version {
                 processArgs.append(contentsOf: ["--version", "\(version)"])
             }
-            processArgs.append("--legacy")
+            processArgs.addLegacyFlagIfNeeded()
 
             let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)
@@ -183,4 +184,24 @@ open class XCResultToolCommand {
             super.init(withXCResult: xcresult, process: process)
         }
     }
+}
+
+// MARK: - Legacy flag
+
+private let shouldAddLegacyFlag: Bool = {
+    guard let xcresulttoolVersion = Version.xcresulttool() else {
+      return false
+    }
+
+    let versionWithDeprecatedAPIs = Version.xcresulttoolWithDeprecatedAPIs()
+
+    return xcresulttoolVersion >= versionWithDeprecatedAPIs
+}()
+
+private extension Array where Element: StringProtocol {
+  mutating func addLegacyFlagIfNeeded() {
+    if shouldAddLegacyFlag {
+      self.append("--legacy")
+    }
+  }
 }

--- a/Sources/XCParseCore/XCResultToolCommand.swift
+++ b/Sources/XCParseCore/XCResultToolCommand.swift
@@ -129,6 +129,7 @@ open class XCResultToolCommand {
             if self.outputPath != "" {
                 processArgs.append(contentsOf: ["--output-path", self.outputPath])
             }
+            processArgs.append("--legacy")
 
             let process = TSCBasic.Process(arguments: processArgs)
             super.init(withXCResult: xcresult, process: process)


### PR DESCRIPTION
**Change Description:**

As discussed in #87. This is a short term solution, for a long term one the `xcresulttool` usage is to be later reviewed.

I didn't simply change `XCResultToolCommand:13` to include `--legacy` because some commands don't require and fail when it gets added, such as `MetadataGet` and `Version`

**Test Plan/Testing Performed:**

- I didn't find tests covering the `xcresulttool` command that is generated, to extend asserting for the presence of `--legacy`, but please let me know if there's one or if I should write a test for it
- The tests pass on my machine (macOS Sonoma 14.6.1 / Xcode 16), but fail on CI - I don't have access to check which test is failing and why

